### PR TITLE
Feature: API: add user to organization. 

### DIFF
--- a/apps/api/openapi.yaml
+++ b/apps/api/openapi.yaml
@@ -234,6 +234,28 @@ components:
       description: Opaque response proxied from external conformance service.
       type: object
       additionalProperties: true
+    AddUserToOrganizationRequest:
+      type: object
+      properties:
+        fullName: { type: string, description: "Full name of the user", example: "John Doe" }
+        email: { type: string, format: email, description: "Email address of the user", example: "john.doe@example.com" }
+        role: { type: string, description: "Role of the user in the organization", example: "user" }
+        password: { type: string, format: password, description: "Password for the user account", minLength: 6 }
+        confirmPassword: { type: string, format: password, description: "Password confirmation" }
+      required: [fullName, email, role, password, confirmPassword]
+    UserContext:
+      type: object
+      properties:
+        userId: { type: integer, description: "Unique identifier for the user", example: 123 }
+        email: { type: string, format: email, description: "User's email address", example: "user@example.com" }
+        organizationId: { type: integer, description: "ID of the organization the user belongs to", example: 456 }
+        role: { type: string, description: "User's role in the organization", example: "user" }
+        policies: 
+          type: array
+          items: { type: string }
+          description: "List of policies/permissions assigned to the user"
+          example: ["view-users", "edit-users"]
+      required: [userId, email, organizationId, role, policies]
   responses:
     Unauthorized:
       description: Unauthorized
@@ -442,6 +464,33 @@ paths:
               schema:
                 type: array
                 items: { $ref: '#/components/schemas/UserBase' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+    post:
+      summary: Add a new user to an organization
+      tags: [Organizations]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: integer }
+          description: Organization ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddUserToOrganizationRequest'
+      responses:
+        '201':
+          description: User successfully added to organization
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserContext'
+        '400': { $ref: '#/components/responses/BadRequest' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -1,7 +1,7 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { authenticate } from '../middleware/authentication';
 import { Services } from '@src/services';
-import { LoginData, UserContext } from '@src/services/user-service';
+import { LoginData, UserContext, AddUserToOrganizationData } from '@src/services/user-service';
 import jwt from 'jsonwebtoken';
 import config from '@src/common/config';
 import logger from '@src/common/logger';
@@ -114,6 +114,12 @@ router.get('/directory/organizations/:id/users', authenticate, context(async (re
     req.context,
     parseInt(req.params.id)
   );
+}));
+
+// Add a user to an organization
+router.post('/directory/organizations/:id/users', authenticate, context(async (req) => {
+  const organizationId = parseInt(req.params.id);
+  return req.services.user.addUserToOrganization(req.context, organizationId, req.body as AddUserToOrganizationData);
 }));
 
 // Connections between organizations


### PR DESCRIPTION
Endpoint for creating and adding new users to an organization..

**API and Data Model Additions**

* Introduced the `AddUserToOrganizationData` TypeScript interface in `user-service.ts` to define the structure of user creation data.
* Added a new OpenAPI schema `AddUserToOrganizationRequest` for the request body and `UserContext` for the response, specifying required fields and types for user creation in an organization.

**Endpoint Implementation**

* Added a new POST endpoint `/directory/organizations/:id/users` to `openapi.yaml` and Express router, allowing authenticated users to add a user to a specified organization. The endpoint validates input and returns the new user's context. [[1]](diffhunk://#diff-61668605b98c3872c43d52fbe82632e5086ff6ee9309a736f3c8ece8ee02e816R470-R496) [[2]](diffhunk://#diff-14d8b2e1724306312e79b75d2620f592dfe2409eb99d28a65e7b28ae792f3a8bR119-R124)

**Service Logic and Security**

* Implemented the `addUserToOrganization` method in `UserService`, which:
  - Validates password match and email uniqueness.
  - Checks organization existence.
  - Hashes the password.
  - Creates the user and sends a welcome email.
  - Returns the user's context.
  - Enforces access control using the new `add-users` policy.

**Policy Management**

* Registered the new `add-users` policy and integrated access checks for user creation in an organization.