### PR TITLE
[147] Fix pagination for organizations listing

### DIFF
--- a/apps/api/src/common/mock-utils.ts
+++ b/apps/api/src/common/mock-utils.ts
@@ -46,6 +46,10 @@ export const createMockQueryChain = (executors = createMockExecutors()) => ({
 
   // grouping methods
   groupBy: jest.fn().mockReturnThis(),
+
+  // $if
+  $if: jest.fn().mockReturnThis(),
+  $call: jest.fn().mockReturnThis(),
   
   // Execution methods
   ...executors,


### PR DESCRIPTION
Fixes an issue where the pagination parameters were being applied to the already grouped by results in organizationService.list() method.