### PR TITLE
[148] Allow root roles to promote other users to root

### DIFF
--- a/apps/api/src/services/organization-service.ts
+++ b/apps/api/src/services/organization-service.ts
@@ -15,6 +15,7 @@ registerPolicy([Role.Root], 'view-connections-all-organizations');
 registerPolicy([Role.Root], 'edit-connections-all-organizations');
 registerPolicy([Role.Root], 'view-all-organizations');
 registerPolicy([Role.Root], 'edit-all-organizations');
+registerPolicy([Role.Root], 'assign-root-role');
 
 export interface OrganizationData {
   id: number;
@@ -377,9 +378,7 @@ export class OrganizationService {
     const allowed = 
       context.policies.includes('edit-all-organizations') ||
       context.policies.includes('edit-own-organizations') && context.organizationId === organizationId;
-    if (!allowed) {
-      throw new ForbiddenError('You are not allowed to edit members of this organization');
-    }
+
     if (!allowed) {
       throw new ForbiddenError('You are not allowed to edit members of this organization');
     }
@@ -393,6 +392,13 @@ export class OrganizationService {
 
     if (!user) {
       throw new NotFoundError('User not found');
+    }
+
+    if (update.role === Role.Root) {
+      // Only root users can assign root role
+      if (!hasAccess(context, 'assign-root-role')) {
+        throw new ForbiddenError('You are not allowed to assign root role');
+      }
     }
 
     // Can only enable a user that is currently disabled

--- a/apps/directory-portal/src/pages/EditUserPage.tsx
+++ b/apps/directory-portal/src/pages/EditUserPage.tsx
@@ -21,6 +21,7 @@ import SideNav from "../components/SideNav";
 import { User } from "./OrganizationUsers";
 import { fetchWithAuth } from "../utils/auth-fetch";
 import "./EditUserPage.css";
+import PolicyGuard from "../components/PolicyGuard";
 
 const EditUserPage: React.FC = () => {
   const navigate = useNavigate();
@@ -223,6 +224,14 @@ const EditUserPage: React.FC = () => {
                         <Select.Item value="user" className="select-item">
                           <Select.ItemText>User</Select.ItemText>
                         </Select.Item>
+                        <PolicyGuard policies={["assign-root-role"]}>
+                          <Select.Item
+                            value="root"
+                            className="select-item"
+                          >
+                            <Select.ItemText>Root</Select.ItemText>
+                          </Select.Item>
+                        </PolicyGuard>
                       </Select.Viewport>
                     </Select.Content>
                   </Select.Portal>


### PR DESCRIPTION
Allows only root users to promote other users to root:

- Adds the root role as an option in EditUser page select
- Adds a new policy assign-root-role attached to root role
- Adds a guard in the updateMember endpoint which only allows this policy to assign root roles