### PR TITLE
[165] Add connections count for NodesList

### DIFF
--- a/apps/api/openapi.yaml
+++ b/apps/api/openapi.yaml
@@ -257,6 +257,7 @@ components:
         status: { type: string, enum: [active, inactive, pending] }
         createdAt: { type: string, format: date-time }
         updatedAt: { type: string, format: date-time }
+        connectionsCount: { type: integer, description: "Total number of incoming and outgoing connections" }
       required: [id, organizationId, name, type, apiUrl, status, createdAt, updatedAt]
     CreateNodeRequest:
       type: object

--- a/apps/api/src/services/node-service.test.ts
+++ b/apps/api/src/services/node-service.test.ts
@@ -396,6 +396,7 @@ describe('NodeService', () => {
           createdAt: new Date(),
           updatedAt: new Date(),
           organizationName: 'Test Org',
+          connectionsCount: 3,
         },
         {
           id: 2,
@@ -407,6 +408,7 @@ describe('NodeService', () => {
           createdAt: new Date(),
           updatedAt: new Date(),
           organizationName: 'Test Org',
+          connectionsCount: 5,
         },
       ];
 
@@ -417,6 +419,8 @@ describe('NodeService', () => {
 
       expect(result.data).toEqual(mockNodes);
       expect(result.pagination.total).toBe(2);
+      expect(result.data[0].connectionsCount).toBe(3);
+      expect(result.data[1].connectionsCount).toBe(5);
     });
 
     it('should apply filters correctly', async () => {
@@ -427,6 +431,67 @@ describe('NodeService', () => {
       await nodeService.list(adminUserContext, 1, query);
 
       expect(dbMocks.queryChain.where).toHaveBeenCalled();
+    });
+
+    it('should include connectionsCount in response', async () => {
+      const mockNodes = [
+        {
+          id: 1,
+          organizationId: 1,
+          name: 'Node with connections',
+          type: 'internal',
+          apiUrl: 'http://example1.com',
+          status: 'active',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          organizationName: 'Test Org',
+          connectionsCount: 10,
+        },
+        {
+          id: 2,
+          organizationId: 1,
+          name: 'Node without connections',
+          type: 'external',
+          apiUrl: 'http://example2.com',
+          status: 'active',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          organizationName: 'Test Org',
+          connectionsCount: 0,
+        },
+      ];
+
+      dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce({ total: 2 });
+      dbMocks.executors.execute.mockResolvedValueOnce(mockNodes);
+
+      const result = await nodeService.list(adminUserContext, 1, ListQuery.default());
+
+      expect(result.data).toHaveLength(2);
+      expect(result.data[0]).toHaveProperty('connectionsCount');
+      expect(result.data[0].connectionsCount).toBe(10);
+      expect(result.data[1].connectionsCount).toBe(0);
+    });
+
+    it('should count both incoming and outgoing connections', async () => {
+      const mockNode = {
+        id: 1,
+        organizationId: 1,
+        name: 'Node with bidirectional connections',
+        type: 'internal',
+        apiUrl: 'http://example.com',
+        status: 'active',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        organizationName: 'Test Org',
+        connectionsCount: 7, // Total of incoming + outgoing
+      };
+
+      dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce({ total: 1 });
+      dbMocks.executors.execute.mockResolvedValueOnce([mockNode]);
+
+      const result = await nodeService.list(adminUserContext, 1, ListQuery.default());
+
+      expect(result.data[0].connectionsCount).toBe(7);
     });
   });
 });

--- a/apps/api/src/services/node-service.ts
+++ b/apps/api/src/services/node-service.ts
@@ -1,7 +1,7 @@
 import { Kysely } from 'kysely';
 import { Database } from '@src/database/types';
 import { NotFoundError, ForbiddenError, BadRequestError } from '@src/common/errors';
-import { registerPolicy, checkAccess, Role } from '@src/common/policies';
+import { registerPolicy, Role } from '@src/common/policies';
 import { UserContext } from './user-service';
 import { ListQuery, ListResult } from '@src/common/list-query';
 import config from '@src/common/config';
@@ -22,6 +22,7 @@ export interface NodeData {
   status: NodeStatus;
   createdAt: Date;
   updatedAt: Date;
+  connectionsCount?: number;
 }
 
 export type NodeStatus = 'active' | 'inactive' | 'pending';
@@ -259,7 +260,6 @@ export class NodeService {
     query: ListQuery = ListQuery.default()
   ): Promise<ListResult<NodeData>> {
 
-    console.log('query', query);
     // Check access
     const allowed =
       context.policies.includes('view-nodes-all-organizations') ||
@@ -284,6 +284,20 @@ export class NodeService {
         'nodes.updatedAt',
         'organizations.name as organizationName',
       ])
+      .select((eb) =>
+        eb
+          .selectFrom('connections')
+          .select((eb2) =>
+            eb2.fn.count<number>('connections.id').distinct().as('count')
+          )
+          .where((wb) =>
+            wb.or([
+              wb('connections.fromNodeId', '=', eb.ref('nodes.id')),
+              wb('connections.targetNodeId', '=', eb.ref('nodes.id')),
+            ])
+          )
+          .as('connectionsCount')
+      )
 
     // Filter by organization only for non-root users
     if (!context.policies.includes('view-nodes-all-organizations')) {

--- a/apps/directory-portal/src/pages/NodesList.tsx
+++ b/apps/directory-portal/src/pages/NodesList.tsx
@@ -18,6 +18,7 @@ export interface Node {
   status: 'active' | 'inactive' | 'pending';
   createdAt: string;
   updatedAt: string;
+  connectionsCount?: number;
 }
 
 const NodesList: React.FC = () => {
@@ -71,6 +72,17 @@ const NodesList: React.FC = () => {
       sortValue: (row: Node) => row.type,
       render: (row: Node) => (
         <span style={{ textTransform: 'capitalize' }}>{row.type}</span>
+      ),
+    },
+    {
+      key: "connectionsCount",
+      header: "Connections",
+      sortable: true,
+      sortValue: (row: Node) => row.connectionsCount ?? 0,
+      render: (row: Node) => (
+        <span>
+          {row.connectionsCount ?? 0}
+        </span>
       ),
     },
     {


### PR DESCRIPTION
- Adds the aggregate distinct count for connections for each node in the list() method of NodeService
- Adjusts the openapi.yaml, tests and UI