### PR TITLE
Minor fixes and enhancements for the grid

### DIFF
--- a/apps/directory-portal/src/components/DataTable.tsx
+++ b/apps/directory-portal/src/components/DataTable.tsx
@@ -224,7 +224,16 @@ function DataTable<T extends object>({
             
             return (
               <tr
-                onClick={() => onRowClick && onRowClick(row)}
+                onClick={(e) => {
+                  // Prevent row click if the click originated from the checkbox
+                  if ((e.target as HTMLElement).closest(".checkbox-column")) {
+                    return;
+                  }
+                  
+                  if (onRowClick) {
+                    onRowClick(row);
+                  }
+                }}
                 key={String(rowId)}
                 className={`${isSelected ? "selected-row" : ""} ${isDisabled ? "disabled-row" : ""}`}
               >

--- a/apps/directory-portal/src/components/SearchableDataTable.tsx
+++ b/apps/directory-portal/src/components/SearchableDataTable.tsx
@@ -54,6 +54,9 @@ export interface SearchableDataTableProps<T> {
   
   // Search debounce delay in ms
   searchDebounceMs?: number;
+
+  // Row click handler
+  onRowClick?: (rowData: T) => void;
 }
 
 function SearchableDataTable<T extends object>({
@@ -67,6 +70,7 @@ function SearchableDataTable<T extends object>({
   selectable = false,
   selectedIds,
   onSelectionChange,
+  onRowClick,
   selectAllText,
   disabledRowIds,
   onDataLoaded,
@@ -236,6 +240,7 @@ function SearchableDataTable<T extends object>({
         onSelectionChange={onSelectionChange}
         selectAllText={selectAllText}
         disabledRowIds={disabledRowIds}
+        onRowClick={onRowClick}
       />
 
       {/* Paging strip (below) */}

--- a/apps/directory-portal/src/pages/ConformanceTestRuns.tsx
+++ b/apps/directory-portal/src/pages/ConformanceTestRuns.tsx
@@ -131,6 +131,7 @@ const ConformanceTestRuns: React.FC = () => {
           searchPlaceholder="Search by organization name, email address or user name"
           fetchData={fetchTestRuns}
           columns={columns}
+          onRowClick={(row) => navigate(`/conformance-test-result?testRunId=${row.testRunId}`)}
           idColumnName="testRunId"          
           emptyState={{
             title: "You currently have no tests",

--- a/apps/directory-portal/src/pages/EditNodePage.tsx
+++ b/apps/directory-portal/src/pages/EditNodePage.tsx
@@ -61,10 +61,6 @@ const EditNodePage: React.FC = () => {
 
   useEffect(() => {
     const fetchNode = async () => {
-      if (!profileData) {
-        return;
-      }
-
       try {
         const response = await fetchWithAuth(
           `/nodes/${nodeId}`

--- a/apps/directory-portal/src/pages/EditOrganizationPage.tsx
+++ b/apps/directory-portal/src/pages/EditOrganizationPage.tsx
@@ -48,7 +48,6 @@ const EditOrganizationPage: React.FC = () => {
 
   useEffect(() => {
     const fetchOrganization = async () => {
-      if (!profileData) return;
 
       try {
         const response = await fetchWithAuth(

--- a/apps/directory-portal/src/pages/NodesList.tsx
+++ b/apps/directory-portal/src/pages/NodesList.tsx
@@ -31,10 +31,6 @@ const NodesList: React.FC = () => {
     pageSize: number;
     search?: string;
   }): Promise<{ data: Node[]; pagination: PaginationInfo }> => {
-    if (!profileData) {
-      throw new Error("Profile data not available");
-    }
-
     // Build query string
     const queryParams = new URLSearchParams({
       page: params.page.toString(),
@@ -46,7 +42,7 @@ const NodesList: React.FC = () => {
     }
 
     const response = await fetchWithAuth(
-      `/organizations/${profileData.organizationId}/nodes?${queryParams.toString()}`
+      `/organizations/${profileData?.organizationId}/nodes?${queryParams.toString()}`
     );
     
     if (!response || !response.ok) {
@@ -152,6 +148,7 @@ const NodesList: React.FC = () => {
       <SearchableDataTable<Node>
         searchPlaceholder="Search by node name..."
         fetchData={fetchNodes}
+        onRowClick={(row) => navigate(`/nodes/${row.id}/connections`)}
         columns={columns}
         idColumnName="id"
         defaultPageSize={50}

--- a/apps/directory-portal/src/pages/OrganizationUsers.tsx
+++ b/apps/directory-portal/src/pages/OrganizationUsers.tsx
@@ -42,10 +42,6 @@ const OrganizationUsers: React.FC = () => {
     pageSize: number;
     search?: string;
   }): Promise<{ data: User[]; pagination: { page: number; pageSize: number; total: number; totalPages: number; hasNext: boolean; hasPrevious: boolean } }> => {
-    if (!profileData) {
-      throw new Error("Profile data not available");
-    }
-
     const queryParams = new URLSearchParams({
       page: params.page.toString(),
       pageSize: params.pageSize.toString(),
@@ -283,6 +279,7 @@ const OrganizationUsers: React.FC = () => {
         selectable={true}
         selectedIds={selectedUserIds}
         onSelectionChange={setSelectedUserIds}
+        onRowClick={(row) => navigate(`/organization/${row.organizationId}/users/${row.id}`)}
         disabledRowIds={disabledRowIds}
         selectAllText="Select all users"
         onDataLoaded={setUsers}

--- a/apps/directory-portal/src/pages/OrganizationsList.tsx
+++ b/apps/directory-portal/src/pages/OrganizationsList.tsx
@@ -31,10 +31,6 @@ const Organizations: React.FC = () => {
     pageSize: number;
     search?: string;
   }): Promise<{ data: Organization[]; pagination: PaginationInfo }> => {
-    if (!profileData) {
-      throw new Error("Profile data not available");
-    }
-
     // Build query string
     const queryParams = new URLSearchParams({
       page: params.page.toString(),
@@ -131,6 +127,7 @@ const Organizations: React.FC = () => {
     >
       <SearchableDataTable<Organization>
         searchPlaceholder="Search by organization name..."
+        onRowClick={(row) => navigate(`/organizations/${row.id}`)}
         fetchData={fetchOrganizations}
         columns={columns}
         idColumnName="id"


### PR DESCRIPTION
- Fixes an issue where profileData would block loading organizational data on refresh
- Enables clicking an entire row for grids with a default action
   - Users - Edit/view users
   - Nodes - Edit/view connections
   - Orgs - Edit/view orgs
   - TestRuns - View test run details
