### PR TITLE
hotfix: display detailed error information on testrun init

### DIFF
--- a/apps/api/src/services/test-run-service.ts
+++ b/apps/api/src/services/test-run-service.ts
@@ -91,12 +91,15 @@ export class TestRunService {
           }),
         }
       );
-
+      if (!response.ok) {
+        const errorbodyText = await response.text();
+        throw new Error(`Failed to create test run: ${response.status} ${response.statusText} - ${errorbodyText}`);
+      } 
       const responseData: unknown = await response.json();
       return responseData;
     } catch (error) {
       logger.error('createTestRun error', error);
-      throw new Error('Failed to execute test cases.');
+      throw error;
     }
   }
 

--- a/apps/directory-portal/src/pages/ConformanceTestResult.tsx
+++ b/apps/directory-portal/src/pages/ConformanceTestResult.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from "react";
-import { Heading, Text, Button, Box, Badge, Callout } from "@radix-ui/themes";
+import { Heading, Text, Code, Button, Box, Badge, Callout } from "@radix-ui/themes";
 import {
-  ExclamationTriangleIcon,
   ReaderIcon,
   DoubleArrowRightIcon,
 } from "@radix-ui/react-icons";
@@ -170,9 +169,12 @@ const ConformanceTestResult: React.FC = () => {
             resource: authOptions?.resource,
           }),
         });
-
-        if (!response || !response.ok) {
-          throw new Error("Failed to fetch test response");
+        if (!response) {
+          throw new Error("No response from server");
+        }
+        if (!response.ok) {
+          const errorText = await response!.text();
+          throw new Error("Failed to fetch test response: " + response.status + " " + response.statusText + " - " + errorText);
         }
 
         const data = await response.json();
@@ -198,9 +200,7 @@ const ConformanceTestResult: React.FC = () => {
         pollTestResults(1, setTestCases, data.testRunId, isCancelled);
       } catch (error) {
         console.error("Error fetching test response:", error);
-        setError(
-          "An unexpected error occurred while running tests. Please try again."
-        );
+        setError("" + error);
         setIsLoading(false);
       }
     };
@@ -301,13 +301,10 @@ const ConformanceTestResult: React.FC = () => {
           />
         </Box>
       ) : error ? (
-        <Box className="error-container">
+        <Box className="error-container" style={{ width: "unset" }}>
           <h2>Conformance Test Result</h2>
           <Callout.Root color="red" size="2">
-            <Callout.Icon>
-              <ExclamationTriangleIcon />
-            </Callout.Icon>
-            <Callout.Text>{error}</Callout.Text>
+            <Callout.Text><Code>{error}</Code></Callout.Text>
           </Callout.Root>
           <Box mt="4">
             <Button onClick={() => navigate("/conformance-testing")}>


### PR DESCRIPTION
During test run initialization, the conformance tool first performs an authentication request and a list request against the API under test to prepare the individual test cases.

If either of these setup calls fails, the entire test run stops before any individual test case is executed. Previously, the UI showed only a generic, non-informative error in this situation. Since most authentication and connectivity issues occur at this stage, users need clear diagnostic feedback.

This hotfix improves the UI error handling for initialization failures so users see actionable details instead of a generic message.