### PR TITLE
fix: check if organization is active upon login

### DIFF
--- a/apps/api/src/services/auth-service.test.ts
+++ b/apps/api/src/services/auth-service.test.ts
@@ -38,6 +38,25 @@ describe('AuthService', () => {
       await expect(authService.token(loginData)).rejects.toThrow(UnauthorizedError);
     });
 
+    it('should throw UnauthorizedError if organization status is not active', async () => {
+      dbMocks.executors.executeTakeFirst
+        .mockResolvedValueOnce({
+          id: 'c1',
+          clientSecret: 'secret123',
+          networkKey: 'netA',
+          organizationName: 'Client Org',
+          status: 'disabled',
+          email: 'client@test.com',
+        }) // client org
+        .mockResolvedValueOnce({
+          id: 'n1',
+          clientSecret: 'network-secret',
+          networkKey: 'networkXYZ',
+        }); // network org
+
+      await expect(authService.token(loginData)).rejects.toThrow(UnauthorizedError);
+    });
+
     it('should throw UnauthorizedError for invalid client_secret', async () => {
       dbMocks.executors.executeTakeFirst
         .mockResolvedValueOnce({
@@ -45,6 +64,7 @@ describe('AuthService', () => {
           clientSecret: 'wrong-secret',
           networkKey: 'netA',
           organizationName: 'Client Org',
+          status: 'active',
           email: 'client@test.com',
         }) // client org
         .mockResolvedValueOnce({

--- a/apps/api/src/services/auth-service.ts
+++ b/apps/api/src/services/auth-service.ts
@@ -25,6 +25,7 @@ export class AuthService {
         'organizations.clientSecret',
         'organizations.networkKey',
         'organizations.name as organizationName',
+        'organizations.status',
         'users.email',
       ])
       .where('clientId', '=', client_id)
@@ -39,6 +40,11 @@ export class AuthService {
     // Check if both organizations exist
     if (!clientOrganization || !networkOrganization) {
       throw new UnauthorizedError('Invalid client_id or network_id');
+    }
+
+    // Check if the client organization is active
+    if (clientOrganization.status !== 'active') {
+      throw new UnauthorizedError('Organization is not active');
     }
 
     // 2. Check if the client_id and client_secret match the organization


### PR DESCRIPTION
Upon login, the `status` field of the organization will be tested (must be `active`). If not, an UnauthorizedError exception is thrown. Test-case Included. 