### PR TITLE
[249] PCF "Inbox" with incoming and outgoing PCF requests between nodes

### DIFF
--- a/apps/api/src/common/mock-utils.ts
+++ b/apps/api/src/common/mock-utils.ts
@@ -35,6 +35,7 @@ export const createMockQueryChain = (executors = createMockExecutors()) => ({
   values: jest.fn().mockReturnThis(),
   set: jest.fn().mockReturnThis(),
   returningAll: jest.fn().mockReturnThis(),
+  onConflict: jest.fn().mockReturnThis(),
   
   // Pagination
   offset: jest.fn().mockReturnThis(),

--- a/apps/api/src/common/mock-utils.ts
+++ b/apps/api/src/common/mock-utils.ts
@@ -79,6 +79,9 @@ export const createMockDatabase = () => {
     updateTable: jest.fn().mockReturnValue(queryChain),
     withRecursive: jest.fn().mockReturnValue(queryChain),
     
+    // Raw SQL execution — used by sql`` template tag
+    executeQuery: jest.fn().mockResolvedValue({ rows: [] }),
+
     // Transaction support
     transaction: mockTransaction,
   };

--- a/apps/api/src/database/migrations/2026_04_16_10_00_00_extend_pcf_requests_incoming.ts
+++ b/apps/api/src/database/migrations/2026_04_16_10_00_00_extend_pcf_requests_incoming.ts
@@ -1,0 +1,49 @@
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  // Add source column — callback base URL for incoming requests (event.source)
+  await db.schema
+    .alterTable('pcf_requests')
+    .addColumn('source', 'text')
+    .execute();
+
+  // Add fulfilled_footprint_ids — IDs included in RequestFulfilledEvent
+  await db.schema
+    .alterTable('pcf_requests')
+    .addColumn('fulfilled_footprint_ids', 'jsonb')
+    .execute();
+
+  // Make connection_id nullable — incoming requests may not map to a tracked connection
+  await sql`ALTER TABLE pcf_requests ALTER COLUMN connection_id DROP NOT NULL`.execute(db);
+
+  // Make from_node_id nullable — incoming requests from external nodes may not have a node record
+  await sql`ALTER TABLE pcf_requests ALTER COLUMN from_node_id DROP NOT NULL`.execute(db);
+
+  // Drop the FK constraint on from_node_id so NULL values are valid
+  await sql`
+    DO $$
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM information_schema.table_constraints
+        WHERE table_name = 'pcf_requests'
+          AND constraint_name = 'pcf_requests_from_node_id_fkey'
+      ) THEN
+        ALTER TABLE pcf_requests DROP CONSTRAINT pcf_requests_from_node_id_fkey;
+      END IF;
+    END
+    $$
+  `.execute(db);
+
+  // Index on target_node_id for inbox queries
+  await db.schema
+    .createIndex('pcf_requests_target_node_id_idx')
+    .on('pcf_requests')
+    .column('target_node_id')
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropIndex('pcf_requests_target_node_id_idx').execute();
+  await db.schema.alterTable('pcf_requests').dropColumn('fulfilled_footprint_ids').execute();
+  await db.schema.alterTable('pcf_requests').dropColumn('source').execute();
+}

--- a/apps/api/src/database/migrations/2026_04_16_10_00_00_extend_pcf_requests_incoming.ts
+++ b/apps/api/src/database/migrations/2026_04_16_10_00_00_extend_pcf_requests_incoming.ts
@@ -20,19 +20,11 @@ export async function up(db: Kysely<unknown>): Promise<void> {
   await sql`ALTER TABLE pcf_requests ALTER COLUMN from_node_id DROP NOT NULL`.execute(db);
 
   // Drop the FK constraint on from_node_id so NULL values are valid
-  await sql`
-    DO $$
-    BEGIN
-      IF EXISTS (
-        SELECT 1 FROM information_schema.table_constraints
-        WHERE table_name = 'pcf_requests'
-          AND constraint_name = 'pcf_requests_from_node_id_fkey'
-      ) THEN
-        ALTER TABLE pcf_requests DROP CONSTRAINT pcf_requests_from_node_id_fkey;
-      END IF;
-    END
-    $$
-  `.execute(db);
+  await db.schema
+    .alterTable('pcf_requests')
+    .dropConstraint('pcf_requests_from_node_id_fkey')
+    .ifExists()
+    .execute();
 
   // Index on target_node_id for inbox queries
   await db.schema

--- a/apps/api/src/database/migrations/2026_04_17_10_00_00_unique_pact_data_id_per_node.ts
+++ b/apps/api/src/database/migrations/2026_04_17_10_00_00_unique_pact_data_id_per_node.ts
@@ -1,21 +1,53 @@
 import { Kysely, sql } from 'kysely';
 
 /**
- * Add a unique index on (node_id, data->>'id') for product_footprints.
+ * Align product_footprints.id with the PACT footprint ID (data->>'id').
+ * After this migration the composite PK (id, node_id) is the natural key.
  *
- * This enables idempotent upserts when a node receives PCFs via a
- * RequestFulfilledEvent — the same PACT footprint (identified by data.id)
- * should not be duplicated within the same node's records.
+ * Steps:
+ *  1. Backfill: set id = data->>'id' for every existing row.
+ *  2. Drop the auto-generated default (gen_random_uuid()).
+ *  3. Change the PK from (id) → (id, node_id), so the same PACT
+ *     footprint may exist on multiple nodes.
  */
 export async function up(db: Kysely<unknown>): Promise<void> {
+  // 1. Backfill id from data->>'id'
   await sql`
-    CREATE UNIQUE INDEX product_footprints_node_pact_id_key
-    ON product_footprints (node_id, (data->>'id'))
+    UPDATE product_footprints SET id = (data->>'id')::uuid
+    WHERE id != (data->>'id')::uuid
   `.execute(db);
+
+  // 2. Remove the auto-generated default
+  await db.schema
+    .alterTable('product_footprints')
+    .alterColumn('id', (ac) => ac.dropDefault())
+    .execute();
+
+  // 3. Replace single-column PK with composite PK (id, node_id)
+  await db.schema
+    .alterTable('product_footprints')
+    .dropConstraint('product_footprints_pkey')
+    .execute();
+
+  await db.schema
+    .alterTable('product_footprints')
+    .addPrimaryKeyConstraint('product_footprints_pkey', ['id', 'node_id'])
+    .execute();
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {
-  await sql`
-    DROP INDEX IF EXISTS product_footprints_node_pact_id_key
-  `.execute(db);
+  await db.schema
+    .alterTable('product_footprints')
+    .dropConstraint('product_footprints_pkey')
+    .execute();
+
+  await db.schema
+    .alterTable('product_footprints')
+    .addPrimaryKeyConstraint('product_footprints_pkey', ['id'])
+    .execute();
+
+  await db.schema
+    .alterTable('product_footprints')
+    .alterColumn('id', (ac) => ac.setDefault(sql`gen_random_uuid()`))
+    .execute();
 }

--- a/apps/api/src/database/migrations/2026_04_17_10_00_00_unique_pact_data_id_per_node.ts
+++ b/apps/api/src/database/migrations/2026_04_17_10_00_00_unique_pact_data_id_per_node.ts
@@ -1,0 +1,21 @@
+import { Kysely, sql } from 'kysely';
+
+/**
+ * Add a unique index on (node_id, data->>'id') for product_footprints.
+ *
+ * This enables idempotent upserts when a node receives PCFs via a
+ * RequestFulfilledEvent — the same PACT footprint (identified by data.id)
+ * should not be duplicated within the same node's records.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE UNIQUE INDEX product_footprints_node_pact_id_key
+    ON product_footprints (node_id, (data->>'id'))
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    DROP INDEX IF EXISTS product_footprints_node_pact_id_key
+  `.execute(db);
+}

--- a/apps/api/src/database/types.ts
+++ b/apps/api/src/database/types.ts
@@ -108,7 +108,7 @@ export interface ActivityLogsTable {
 }
 
 export interface ProductFootprintsTable {
-  id: Generated<string>; // UUID, auto-generated
+  id: string; // UUID — must equal data.id (the PACT footprint ID)
   nodeId: number;
   data: Record<string, any>; // JSONB
   createdAt: Generated<Date>;

--- a/apps/api/src/database/types.ts
+++ b/apps/api/src/database/types.ts
@@ -117,13 +117,15 @@ export interface ProductFootprintsTable {
 
 export interface PcfRequestsTable {
   id: Generated<number>;
-  fromNodeId: number;
+  fromNodeId: number | null;  // null for requests from external nodes without a directory record
   targetNodeId: number;
-  connectionId: number;
+  connectionId: number | null; // null for incoming requests not yet matched to a connection
   requestEventId: string; // UUID of the sent CloudEvent
+  source: string | null;  // source URL from incoming event — used as callback base
   filters: Record<string, unknown>; // JSONB — FootprintFilters
   status: 'pending' | 'fulfilled' | 'rejected';
   resultCount: number | null;
+  fulfilledFootprintIds: unknown[] | null; // footprint IDs sent in RequestFulfilledEvent
   createdAt: Generated<Date>;
   updatedAt: Generated<Date>;
 }

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -374,13 +374,34 @@ router.post('/directory/nodes/:id/pcf-requests', authenticate, context(async (re
   return result;
 }));
 
-// List outgoing PCF requests for a node
+// List all PCF requests for a node (outgoing + incoming, unified)
 router.get('/directory/nodes/:id/pcf-requests', authenticate, context(async (req) => {
   return req.services.pcfRequest.list(
     req.context,
     parseInt(req.params.id as string),
     ListQuery.parse(req.query)
   );
+}));
+
+// Fulfill an incoming PCF request
+router.post('/directory/nodes/:id/pcf-requests/:requestId/fulfill', authenticate, context(async (req) => {
+  await req.services.pcfRequest.fulfill(
+    req.context,
+    parseInt(req.params.id as string),
+    parseInt(req.params.requestId as string),
+    req.body.footprintIds
+  );
+  return { success: true };
+}));
+
+// Reject an incoming PCF request
+router.post('/directory/nodes/:id/pcf-requests/:requestId/reject', authenticate, context(async (req) => {
+  await req.services.pcfRequest.reject(
+    req.context,
+    parseInt(req.params.id as string),
+    parseInt(req.params.requestId as string)
+  );
+  return { success: true };
 }));
 
 

--- a/apps/api/src/services/footprint-service.ts
+++ b/apps/api/src/services/footprint-service.ts
@@ -62,6 +62,7 @@ export class FootprintService {
     const result = await this.db
       .insertInto('product_footprints')
       .values({
+        id: input.data.id as string,
         nodeId,
         data: input.data,
         createdAt: new Date(),
@@ -234,6 +235,7 @@ export class FootprintService {
         .insertInto('product_footprints')
         .values(
           validItems.map((data) => ({
+            id: data.id as string,
             nodeId,
             data,
             createdAt: new Date(),

--- a/apps/api/src/services/internal-node-pact-service.test.ts
+++ b/apps/api/src/services/internal-node-pact-service.test.ts
@@ -507,11 +507,6 @@ describe('InternalNodePactService', () => {
       });
 
       it('inserts received PCFs into product_footprints when they do not already exist', async () => {
-        // No existing row for each PCF → insert path
-        dbMocks.executors.executeTakeFirst
-          .mockResolvedValueOnce(null)  // PCF 1: no existing row
-          .mockResolvedValueOnce(null); // PCF 2: no existing row
-
         await service.handleEvent(nodeId, {
           ...baseEvent,
           type: EventTypes.RequestFulfilled,
@@ -521,17 +516,14 @@ describe('InternalNodePactService', () => {
           },
         });
 
-        // Two inserts into product_footprints
+        // Two upserts (INSERT...ON CONFLICT) into product_footprints
         const insertCalls = dbMocks.db.insertInto.mock.calls.filter(
           (c) => c[0] === 'product_footprints'
         );
         expect(insertCalls).toHaveLength(2);
       });
 
-      it('updates an existing product_footprint row when the PACT ID already exists', async () => {
-        // Existing row found → update path
-        dbMocks.executors.executeTakeFirst.mockResolvedValueOnce({ id: 'existing-db-uuid' });
-
+      it('upserts an existing product_footprint row when the PACT ID already exists', async () => {
         await service.handleEvent(nodeId, {
           ...baseEvent,
           type: EventTypes.RequestFulfilled,
@@ -541,14 +533,11 @@ describe('InternalNodePactService', () => {
           },
         });
 
-        // updateTable called for product_footprints (as well as pcf_requests)
-        const updateCalls = dbMocks.db.updateTable.mock.calls.map((c) => c[0]);
-        expect(updateCalls).toContain('product_footprints');
-        // No insert for product_footprints
+        // Uses INSERT...ON CONFLICT (upsert) for product_footprints
         const insertCalls = dbMocks.db.insertInto.mock.calls.filter(
           (c) => c[0] === 'product_footprints'
         );
-        expect(insertCalls).toHaveLength(0);
+        expect(insertCalls).toHaveLength(1);
       });
 
       it('still updates pcf_requests when pfs array is empty', async () => {

--- a/apps/api/src/services/internal-node-pact-service.test.ts
+++ b/apps/api/src/services/internal-node-pact-service.test.ts
@@ -27,49 +27,111 @@ describe('InternalNodePactService', () => {
 
   const nodeId = 1;
 
-  const mockFootprintData = {
-    id: 'b1f8c0d2-7c4e-4e67-9a9c-2e4c12345678',
+  // ── Real silversurfer23 PCF fixtures (from production DB) ────────────────
+  // Three distinct footprints: US laptop, DE steel, NL compostable container.
+  // Used across all filter tests to get realistic coverage.
+
+  const laptopData = {
+    id: 'd9be4477-e351-45b3-acd9-e1da05e6f633',
     specVersion: '3.0.0',
     version: 1,
-    created: '2023-01-15T10:15:30Z',
+    created: '2023-07-01T00:00:00Z',
     status: 'Active',
     validityPeriodStart: '2023-01-15T10:15:30Z',
     validityPeriodEnd: '2025-12-31T00:00:00Z',
-    companyName: 'Acme Corp',
-    companyIds: ['urn:uuid:abc12345-6789-4def-0123-456789abcdef'],
-    productDescription: 'Renewable Diesel',
-    productIds: ['urn:gtin:1234567890123'],
-    productClassifications: ['urn:eclass:0173-1#01-AAA123#005'],
-    productNameCompany: 'Renewable Diesel',
+    companyName: 'Example Company Inc.',
+    companyIds: ['urn:uuid:12345678-1234-1234-1234-123456789012'],
+    productDescription: 'Exemplary Laptop Model X',
+    productIds: ['urn:gtin:12345678'],
+    productNameCompany: 'Laptop Model X',
+    productClassifications: ['urn:pact:productclassification:un-cpc:452'],
     pcf: {
-      declaredUnitOfMeasurement: 'liter',
-      declaredUnitAmount: '1',
-      geographyCountry: 'DE',
-      referencePeriodStart: '2024-02-28T00:00:00+00:00',
-      referencePeriodEnd: '2024-09-30T00:00:00+00:00',
-      boundaryProcessesDescription: 'Cradle-to-gate',
-      pcfExcludingBiogenicUptake: '77.0',
-      pcfIncludingBiogenicUptake: '77.0',
-      fossilCarbonContent: '11.72',
+      geographyCountry: 'US',
+      declaredUnitOfMeasurement: 'kilogram',
+      declaredUnitAmount: '1.0',
+      referencePeriodStart: '2022-01-01T00:00:00Z',
+      referencePeriodEnd: '2022-12-31T23:59:59Z',
+      pcfExcludingBiogenicUptake: '120.5',
+      pcfIncludingBiogenicUptake: '120.5',
+      fossilGhgEmissions: '115.2',
+      fossilCarbonContent: '5.3',
+      boundaryProcessesDescription: 'Cradle-to-gate assessment',
       ipccCharacterizationFactors: ['AR6'],
+      crossSectoralStandards: ['GHGP-Product', 'ISO14067'],
+      exemptedEmissionsPercent: '2.5',
+      packagingEmissionsIncluded: true,
+      packagingGhgEmissions: '8.3',
     },
   };
 
-  const mockFootprintRow = {
-    data: mockFootprintData,
-  };
-
-  const mockFootprintData2 = {
-    ...mockFootprintData,
-    id: 'c2e9d1f3-8d5f-5f78-0b0d-3f5e23456789',
-    productDescription: 'Bio-Ethanol',
-    productIds: ['urn:gtin:1234567890456'],
-    companyIds: ['urn:uuid:other-company-id'],
+  const steelData = {
+    id: 'f8c3d912-7b4e-4a2c-b567-8e9f0a1b2c3d',
+    specVersion: '3.0.0',
+    version: 2,
+    created: '2023-08-15T00:00:00Z',
+    status: 'Active',
+    validityPeriodStart: '2023-01-15T10:15:30Z',
+    validityPeriodEnd: '2025-12-31T00:00:00Z',
+    companyName: 'Green Materials Corp',
+    companyIds: ['urn:uuid:87654321-4321-4321-4321-210987654321'],
+    productDescription: 'Sustainable Steel Beam Grade A',
+    productIds: ['urn:gtin:87654321', 'urn:ean:9876543210123'],
+    productNameCompany: 'EcoSteel Beam A500',
+    productClassifications: ['urn:pact:productclassification:un-cpc:412'],
     pcf: {
-      ...mockFootprintData.pcf,
-      geographyCountry: 'NL',
+      geographyCountry: 'DE',
+      declaredUnitOfMeasurement: 'kilogram',
+      declaredUnitAmount: '1000.0',
+      referencePeriodStart: '2023-01-01T00:00:00Z',
+      referencePeriodEnd: '2023-06-30T23:59:59Z',
+      pcfExcludingBiogenicUptake: '450.8',
+      pcfIncludingBiogenicUptake: '420.5',
+      fossilGhgEmissions: '440.2',
+      fossilCarbonContent: '10.6',
+      boundaryProcessesDescription: 'Cradle-to-gate including iron ore mining',
+      ipccCharacterizationFactors: ['AR6'],
+      crossSectoralStandards: ['ISO14067', 'ISO14040-44'],
+      exemptedEmissionsPercent: '1.8',
     },
   };
+
+  const containerData = {
+    id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+    specVersion: '3.0.0',
+    version: 1,
+    created: '2023-09-20T00:00:00Z',
+    status: 'Active',
+    validityPeriodStart: '2023-09-01T00:00:00Z',
+    validityPeriodEnd: '2024-08-31T23:59:59Z',
+    companyName: 'BioPack Solutions',
+    companyIds: ['urn:uuid:abcdef12-3456-7890-abcd-ef1234567890'],
+    productDescription: 'Compostable Food Container 500ml',
+    productIds: ['urn:gtin:55667788'],
+    productNameCompany: 'EcoContainer 500',
+    productClassifications: ['urn:pact:productclassification:un-cpc:893'],
+    pcf: {
+      geographyCountry: 'NL',
+      declaredUnitOfMeasurement: 'kilogram',
+      declaredUnitAmount: '0.025',
+      referencePeriodStart: '2023-01-01T00:00:00Z',
+      referencePeriodEnd: '2023-08-31T23:59:59Z',
+      pcfExcludingBiogenicUptake: '0.85',
+      pcfIncludingBiogenicUptake: '-0.15',
+      fossilGhgEmissions: '0.75',
+      fossilCarbonContent: '0.10',
+      boundaryProcessesDescription: 'Cradle-to-gate',
+      ipccCharacterizationFactors: ['AR5'],
+      crossSectoralStandards: ['GHGP-Product'],
+      exemptedEmissionsPercent: '3.2',
+    },
+  };
+
+  // Keep a generic fixture for non-filter tests (avoids updating every mock setup)
+  const mockFootprintData = laptopData;
+  const mockFootprintData2 = steelData;
+
+  const mockFootprintRow = { data: mockFootprintData };
+  const mockFootprintRow2 = { data: mockFootprintData2 };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -133,54 +195,93 @@ describe('InternalNodePactService', () => {
       const result = await service.getFootprints(
         nodeId,
         {
-          productId: ['urn:gtin:1234567890123'],
+          productId: ['urn:gtin:12345678'],   // matches laptopData
           status: 'Active',
         }
       );
 
       expect(result.data).toHaveLength(1);
+      expect(result.data[0].id).toBe(laptopData.id);
     });
 
-    it('should handle geography filter', async () => {
+    it('should handle geography filter — matching country returns results', async () => {
       dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce({ total: 1 });
-      dbMocks.executors.execute.mockResolvedValueOnce([mockFootprintRow]);
+      dbMocks.executors.execute.mockResolvedValueOnce([{ data: steelData }]);
 
       const result = await service.getFootprints(nodeId, { geography: ['DE'] });
 
       expect(result.data).toHaveLength(1);
+      expect(result.data[0].pcf.geographyCountry).toBe('DE');
     });
 
-    it('should handle classification filter', async () => {
+    it('should handle geography filter — no match returns empty', async () => {
+      dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce({ total: 0 });
+      dbMocks.executors.execute.mockResolvedValueOnce([]);
+
+      const result = await service.getFootprints(nodeId, { geography: ['JP'] });
+
+      expect(result.data).toEqual([]);
+    });
+
+    it('should handle classification filter — urn:pact:productclassification:un-cpc:452 matches laptop', async () => {
       dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce({ total: 1 });
       dbMocks.executors.execute.mockResolvedValueOnce([mockFootprintRow]);
 
       const result = await service.getFootprints(
         nodeId,
-        { classification: ['urn:eclass:0173-1#01-AAA123#005'] }
+        { classification: ['urn:pact:productclassification:un-cpc:452'] }
+      );
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].productClassifications).toContain('urn:pact:productclassification:un-cpc:452');
+    });
+
+    it('should handle classification filter — no match returns empty', async () => {
+      dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce({ total: 0 });
+      dbMocks.executors.execute.mockResolvedValueOnce([]);
+
+      const result = await service.getFootprints(
+        nodeId,
+        { classification: ['urn:pact:productclassification:un-cpc:999'] }
+      );
+
+      expect(result.data).toEqual([]);
+    });
+
+    it('should handle validOn filter — date within validity window', async () => {
+      dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce({ total: 1 });
+      dbMocks.executors.execute.mockResolvedValueOnce([mockFootprintRow]);
+
+      // laptopData validityPeriodStart='2023-01-15', validityPeriodEnd='2025-12-31'
+      const result = await service.getFootprints(
+        nodeId,
+        { validOn: '2024-06-01T00:00:00Z' }
       );
 
       expect(result.data).toHaveLength(1);
     });
 
-    it('should handle validOn filter', async () => {
-      dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce({ total: 1 });
-      dbMocks.executors.execute.mockResolvedValueOnce([mockFootprintRow]);
+    it('should handle validOn filter — expired container returns empty', async () => {
+      // containerData validityPeriodEnd='2024-08-31' — expired before 2025
+      dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce({ total: 0 });
+      dbMocks.executors.execute.mockResolvedValueOnce([]);
 
       const result = await service.getFootprints(
         nodeId,
-        { validOn: '2023-01-15T10:15:30Z' }
+        { validOn: '2025-01-01T00:00:00Z' }
       );
 
-      expect(result.data).toHaveLength(1);
+      expect(result.data).toEqual([]);
     });
 
     it('should handle validAfter filter', async () => {
       dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce({ total: 1 });
       dbMocks.executors.execute.mockResolvedValueOnce([mockFootprintRow]);
 
+      // laptopData validityPeriodStart='2023-01-15', after 2023-01-14
       const result = await service.getFootprints(
         nodeId,
-        { validAfter: '2023-01-14T10:15:30Z' }
+        { validAfter: '2023-01-14T00:00:00Z' }
       );
 
       expect(result.data).toHaveLength(1);
@@ -190,6 +291,7 @@ describe('InternalNodePactService', () => {
       dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce({ total: 1 });
       dbMocks.executors.execute.mockResolvedValueOnce([mockFootprintRow]);
 
+      // laptopData validityPeriodEnd='2025-12-31', before 2026-01-01
       const result = await service.getFootprints(
         nodeId,
         { validBefore: '2026-01-01T00:00:00Z' }
@@ -198,25 +300,37 @@ describe('InternalNodePactService', () => {
       expect(result.data).toHaveLength(1);
     });
 
-    it('should handle companyId filter with OR logic (Test Case #29)', async () => {
+    it('should handle companyId filter — matches laptop with urn:uuid:12345678-1234-1234-1234-123456789012', async () => {
       dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce({ total: 1 });
       dbMocks.executors.execute.mockResolvedValueOnce([mockFootprintRow]);
 
       const result = await service.getFootprints(
         nodeId,
+        { companyId: ['urn:uuid:12345678-1234-1234-1234-123456789012'] }
+      );
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].companyIds).toContain('urn:uuid:12345678-1234-1234-1234-123456789012');
+    });
+
+    it('should handle companyId filter — OR logic: multiple IDs, any match suffices', async () => {
+      dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce({ total: 2 });
+      dbMocks.executors.execute.mockResolvedValueOnce([mockFootprintRow, mockFootprintRow2]);
+
+      const result = await service.getFootprints(
+        nodeId,
         {
           companyId: [
-            'urn:uuid:abc12345-6789-4def-0123-456789abcdef',
-            'urn:uuid:other-company',
-            'urn:uuid:another-company',
+            'urn:uuid:12345678-1234-1234-1234-123456789012',  // laptop
+            'urn:uuid:87654321-4321-4321-4321-210987654321',  // steel
           ],
         }
       );
 
-      expect(result.data).toHaveLength(1);
+      expect(result.data).toHaveLength(2);
     });
 
-    it('should handle combined status and productId filter (Test Case #28)', async () => {
+    it('should handle combined status and productId filter', async () => {
       dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce({ total: 1 });
       dbMocks.executors.execute.mockResolvedValueOnce([mockFootprintRow]);
 
@@ -224,14 +338,27 @@ describe('InternalNodePactService', () => {
         nodeId,
         {
           status: 'Active',
-          productId: ['urn:gtin:1234567890123'],
+          productId: ['urn:gtin:12345678'],
         }
       );
 
       expect(result.data).toHaveLength(1);
     });
 
-    it('should return empty data for non-matching negative filter (Test Case #30-39)', async () => {
+    it('should handle productId filter — steel has two IDs, either match', async () => {
+      dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce({ total: 1 });
+      dbMocks.executors.execute.mockResolvedValueOnce([{ data: steelData }]);
+
+      const result = await service.getFootprints(
+        nodeId,
+        { productId: ['urn:ean:9876543210123'] }  // second ID of steelData
+      );
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].productIds).toContain('urn:ean:9876543210123');
+    });
+
+    it('should return empty data for non-matching productId filter', async () => {
       dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce({ total: 0 });
       dbMocks.executors.execute.mockResolvedValueOnce([]);
 
@@ -328,79 +455,32 @@ describe('InternalNodePactService', () => {
         await new Promise((resolve) => setTimeout(resolve, 50));
       });
 
-      it('should send RequestFulfilledEvent when matching footprints are found (Test Case #13)', async () => {
-        // Mock: matching footprint found
-        dbMocks.executors.execute.mockResolvedValueOnce([mockFootprintRow]);
-        // Mock: outgoing connection for callback auth
-        dbMocks.executors.executeTakeFirst.mockResolvedValueOnce({
-          clientId: 'test-client',
-          clientSecret: Buffer.from('test-secret').toString('base64'),
-        });
-        // Mock: auth token response
-        mockFetch.mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ access_token: 'callback-token' }),
-        });
-        // Mock: callback POST
-        mockFetch.mockResolvedValueOnce({ ok: true });
+      it('should save incoming request to inbox regardless of footprint matches (Test Case #13)', async () => {
+        // New behavior: always save to inbox, never auto-respond
+        await expect(
+          service.handleEvent(nodeId, {
+            ...baseEvent,
+            type: EventTypes.RequestCreated,
+            data: { productId: ['urn:gtin:1234567890123'] },
+          })
+        ).resolves.toBeUndefined();
 
-        await service.handleEvent(nodeId, {
-          ...baseEvent,
-          type: EventTypes.RequestCreated,
-          data: { productId: ['urn:gtin:1234567890123'] },
-        });
-
-        // Give the fire-and-forget promise time to resolve
-        await new Promise((resolve) => setTimeout(resolve, 100));
-
-        // Verify the callback was made
-        const callbackCall = mockFetch.mock.calls.find(
-          (call) => call[0].includes('/3/events')
-        );
-        expect(callbackCall).toBeDefined();
-        if (callbackCall && callbackCall[1]) {
-          const body = JSON.parse(callbackCall[1].body);
-          expect(body.type).toBe(EventTypes.RequestFulfilled);
-          expect(body.data.requestEventId).toBe('test-event-123');
-          expect(body.data.pfs).toHaveLength(1);
-        }
+        // No callback should be made — supplier fulfills manually via dashboard
+        expect(mockFetch).not.toHaveBeenCalled();
       });
 
-      it('should send RequestRejectedEvent for non-existent productId (Test Case #14)', async () => {
-        // Mock: no matching footprints
-        dbMocks.executors.execute.mockResolvedValueOnce([]);
-        // Mock: outgoing connection for callback auth
-        dbMocks.executors.executeTakeFirst.mockResolvedValueOnce({
-          clientId: 'test-client',
-          clientSecret: Buffer.from('test-secret').toString('base64'),
-        });
-        // Mock: auth token response
-        mockFetch.mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ access_token: 'callback-token' }),
-        });
-        // Mock: callback POST
-        mockFetch.mockResolvedValueOnce({ ok: true });
+      it('should save incoming request to inbox for any productId (Test Case #14)', async () => {
+        // New behavior: always save to inbox, no auto-rejection
+        await expect(
+          service.handleEvent(nodeId, {
+            ...baseEvent,
+            type: EventTypes.RequestCreated,
+            data: { productId: ['urn:null'] },
+          })
+        ).resolves.toBeUndefined();
 
-        await service.handleEvent(nodeId, {
-          ...baseEvent,
-          type: EventTypes.RequestCreated,
-          data: { productId: ['urn:null'] },
-        });
-
-        // Give the fire-and-forget promise time to resolve
-        await new Promise((resolve) => setTimeout(resolve, 100));
-
-        const callbackCall = mockFetch.mock.calls.find(
-          (call) => call[0].includes('/3/events')
-        );
-        expect(callbackCall).toBeDefined();
-        if (callbackCall && callbackCall[1]) {
-          const body = JSON.parse(callbackCall[1].body);
-          expect(body.type).toBe(EventTypes.RequestRejected);
-          expect(body.data.requestEventId).toBe('test-event-123');
-          expect(body.data.error.code).toBe('NotFound');
-        }
+        // No callback should be made — supplier fulfills or rejects manually via dashboard
+        expect(mockFetch).not.toHaveBeenCalled();
       });
     });
 

--- a/apps/api/src/services/internal-node-pact-service.test.ts
+++ b/apps/api/src/services/internal-node-pact-service.test.ts
@@ -485,17 +485,109 @@ describe('InternalNodePactService', () => {
     });
 
     describe('RequestFulfilledEvent', () => {
-      it('should acknowledge a RequestFulfilledEvent', async () => {
+      it('acknowledges the event and updates the outgoing pcf_requests row', async () => {
+        // executeTakeFirst = null → insert path (no existing row)
+        dbMocks.executors.executeTakeFirst.mockResolvedValueOnce(null);
+
         await expect(
           service.handleEvent(nodeId, {
             ...baseEvent,
             type: EventTypes.RequestFulfilled,
             data: {
               requestEventId: 'original-request-id',
-              pfs: [mockFootprintData],
+              pfs: [laptopData],
             },
           })
         ).resolves.toBeUndefined();
+
+        // pcf_requests row updated to fulfilled
+        expect(dbMocks.db.updateTable).toHaveBeenCalledWith('pcf_requests');
+        const setCalls = dbMocks.queryChain.set.mock.calls;
+        expect(setCalls.some((c) => c[0]?.status === 'fulfilled')).toBe(true);
+      });
+
+      it('inserts received PCFs into product_footprints when they do not already exist', async () => {
+        // No existing row for each PCF → insert path
+        dbMocks.executors.executeTakeFirst
+          .mockResolvedValueOnce(null)  // PCF 1: no existing row
+          .mockResolvedValueOnce(null); // PCF 2: no existing row
+
+        await service.handleEvent(nodeId, {
+          ...baseEvent,
+          type: EventTypes.RequestFulfilled,
+          data: {
+            requestEventId: 'req-001',
+            pfs: [laptopData, steelData],
+          },
+        });
+
+        // Two inserts into product_footprints
+        const insertCalls = dbMocks.db.insertInto.mock.calls.filter(
+          (c) => c[0] === 'product_footprints'
+        );
+        expect(insertCalls).toHaveLength(2);
+      });
+
+      it('updates an existing product_footprint row when the PACT ID already exists', async () => {
+        // Existing row found → update path
+        dbMocks.executors.executeTakeFirst.mockResolvedValueOnce({ id: 'existing-db-uuid' });
+
+        await service.handleEvent(nodeId, {
+          ...baseEvent,
+          type: EventTypes.RequestFulfilled,
+          data: {
+            requestEventId: 'req-002',
+            pfs: [laptopData],
+          },
+        });
+
+        // updateTable called for product_footprints (as well as pcf_requests)
+        const updateCalls = dbMocks.db.updateTable.mock.calls.map((c) => c[0]);
+        expect(updateCalls).toContain('product_footprints');
+        // No insert for product_footprints
+        const insertCalls = dbMocks.db.insertInto.mock.calls.filter(
+          (c) => c[0] === 'product_footprints'
+        );
+        expect(insertCalls).toHaveLength(0);
+      });
+
+      it('still updates pcf_requests when pfs array is empty', async () => {
+        await service.handleEvent(nodeId, {
+          ...baseEvent,
+          type: EventTypes.RequestFulfilled,
+          data: {
+            requestEventId: 'req-003',
+            pfs: [],
+          },
+        });
+
+        expect(dbMocks.db.updateTable).toHaveBeenCalledWith('pcf_requests');
+        // No product_footprints insert attempted
+        const insertCalls = dbMocks.db.insertInto.mock.calls.filter(
+          (c) => c[0] === 'product_footprints'
+        );
+        expect(insertCalls).toHaveLength(0);
+      });
+
+      it('skips PCF entries that have no id field', async () => {
+        const pfWithoutId = { ...laptopData, id: undefined };
+
+        await expect(
+          service.handleEvent(nodeId, {
+            ...baseEvent,
+            type: EventTypes.RequestFulfilled,
+            data: {
+              requestEventId: 'req-004',
+              pfs: [pfWithoutId],
+            },
+          })
+        ).resolves.toBeUndefined();
+
+        // No product_footprints insert/update for the bad entry
+        const insertCalls = dbMocks.db.insertInto.mock.calls.filter(
+          (c) => c[0] === 'product_footprints'
+        );
+        expect(insertCalls).toHaveLength(0);
       });
     });
 

--- a/apps/api/src/services/internal-node-pact-service.ts
+++ b/apps/api/src/services/internal-node-pact-service.ts
@@ -135,7 +135,7 @@ export class InternalNodePactService {
         // Update the matching outgoing PCF request record
         // The outgoing row has fromNodeId = this node (the one that sent the request)
         const requestEventId = data?.requestEventId as string | undefined;
-        const pfs = data?.pfs as unknown[] | undefined;
+        const pfs = data?.pfs as ProductFootprint[] | undefined;
         if (requestEventId) {
           await this.db
             .updateTable('pcf_requests')
@@ -147,6 +147,40 @@ export class InternalNodePactService {
             .where('requestEventId', '=', requestEventId)
             .where('fromNodeId', '=', nodeId)
             .execute();
+        }
+        // Persist the received PCFs into this node's product_footprints so they
+        // appear in the node's PCF records. Select first to decide insert vs update,
+        // matching on (node_id, data->>'id') — the unique index
+        // product_footprints_node_pact_id_key enforces no duplicate PACT IDs per node.
+        if (pfs && pfs.length > 0) {
+          for (const pf of pfs) {
+            if (!pf?.id) continue;
+            const existing = await this.db
+              .selectFrom('product_footprints')
+              .select('id')
+              .where('nodeId', '=', nodeId)
+              .where(sql`data->>'id'`, '=', pf.id)
+              .executeTakeFirst();
+
+            if (existing) {
+              await this.db
+                .updateTable('product_footprints')
+                .set({ data: pf as unknown as Record<string, unknown>, updatedAt: new Date() })
+                .where('id', '=', existing.id)
+                .execute();
+            } else {
+              await this.db
+                .insertInto('product_footprints')
+                .values({
+                  nodeId,
+                  data: pf as unknown as Record<string, unknown>,
+                  createdAt: new Date(),
+                  updatedAt: new Date(),
+                })
+                .execute();
+            }
+          }
+          logger.info({ nodeId, requestEventId, count: pfs.length }, 'PCFs from fulfilled request saved to node records');
         }
         break;
       }

--- a/apps/api/src/services/internal-node-pact-service.ts
+++ b/apps/api/src/services/internal-node-pact-service.ts
@@ -1,9 +1,8 @@
 import { Kysely, sql } from 'kysely';
 import { Database } from '@src/database/types';
 import { BadRequestError } from '@src/common/errors';
-import { FootprintFilters, PaginationParams, PagedResponse, ProductFootprint, EventTypes, RequestCreatedEvent, BaseEvent, RequestFulfilledEvent, RequestRejectedEvent } from 'pact-data-model/v3_0';
+import { FootprintFilters, PaginationParams, PagedResponse, ProductFootprint, EventTypes, RequestCreatedEvent, BaseEvent } from 'pact-data-model/v3_0';
 import logger from '@src/common/logger';
-import config from '@src/common/config';
 
 /**
  * Service for handling Internal Node PACT API operations
@@ -122,15 +121,9 @@ export class InternalNodePactService {
       case EventTypes.RequestCreated: {
         logger.info(
           { nodeId, eventId: id, source, productId: data?.productId },
-          'Received RequestCreatedEvent for internal node'
+          'Received RequestCreatedEvent for internal node — saving to inbox'
         );
-        // Fire-and-forget: look up footprints and send callback
-        this.handleRequestCreatedEvent(nodeId, id, source, event as RequestCreatedEvent).catch((err) =>
-          logger.error(
-            { nodeId, eventId: id, error: (err as Error).message },
-            'Failed to handle RequestCreatedEvent callback'
-          )
-        );
+        await this.handleRequestCreatedEvent(nodeId, id, source, event as RequestCreatedEvent);
         break;
       }
 
@@ -140,6 +133,7 @@ export class InternalNodePactService {
           'Received RequestFulfilledEvent for internal node'
         );
         // Update the matching outgoing PCF request record
+        // The outgoing row has fromNodeId = this node (the one that sent the request)
         const requestEventId = data?.requestEventId as string | undefined;
         const pfs = data?.pfs as unknown[] | undefined;
         if (requestEventId) {
@@ -151,7 +145,7 @@ export class InternalNodePactService {
               updatedAt: new Date(),
             })
             .where('requestEventId', '=', requestEventId)
-            .where('targetNodeId', '=', nodeId)
+            .where('fromNodeId', '=', nodeId)
             .execute();
         }
         break;
@@ -172,7 +166,7 @@ export class InternalNodePactService {
               updatedAt: new Date(),
             })
             .where('requestEventId', '=', rejectedRequestEventId)
-            .where('targetNodeId', '=', nodeId)
+            .where('fromNodeId', '=', nodeId)
             .execute();
         }
         break;
@@ -187,13 +181,9 @@ export class InternalNodePactService {
 
   /**
    * Handle the async callback flow for a RequestCreatedEvent.
-   *
-   * 1. Search the node's footprints by the requested productId(s).
-   * 2. If found → POST a RequestFulfilledEvent to the source.
-   * 3. If not found → POST a RequestRejectedEvent to the source.
-   *
-   * The `source` field of the incoming event is used as the callback URL's
-   * base, with `/3/events` appended.
+   * Save an incoming RequestCreatedEvent to the pcf_requests table as a pending
+   * inbox item. The supplier (nodeId) will fulfill or reject it manually via the
+   * dashboard. Idempotent on requestEventId.
    */
   private async handleRequestCreatedEvent(
     nodeId: number,
@@ -201,131 +191,31 @@ export class InternalNodePactService {
     source: string,
     event: RequestCreatedEvent
   ): Promise<void> {
-
-    // Use the same filters as ListFootprints
     const filters = event.data as FootprintFilters;
 
-    let query = this.db
-      .selectFrom('product_footprints')
-      .select(['data'])
-      .where('nodeId', '=', nodeId);
+    // Parse fromNodeId from source URL if it's a directory-internal node
+    // e.g. "http://localhost:3010/api/nodes/14" → 14
+    const fromNodeMatch = source.match(/\/api\/nodes\/(\d+)/);
+    const fromNodeId = fromNodeMatch ? parseInt(fromNodeMatch[1], 10) : null;
 
-    query = this.applyFilters(query, filters);
+    await this.db
+      .insertInto('pcf_requests')
+      .values({
+        targetNodeId: nodeId,
+        fromNodeId,
+        connectionId: null,
+        source,
+        requestEventId,
+        filters: filters as unknown as Record<string, unknown>,
+        status: 'pending',
+        resultCount: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .onConflict((oc) => oc.column('requestEventId').doNothing())
+      .execute();
 
-    // Execute the query to get matching footprints
-    const rows = await query.execute();
-    const footprints = rows.map((r) => r.data as unknown as ProductFootprint);
-    
-    // Determine callback URL — the conformance test service or the event source
-    const callbackUrl = source.endsWith('/3/events')
-      ? source
-      : `${source.replace(/\/+$/, '')}/3/events`;
-
-    // Obtain auth token for the callback
-    const authToken = await this.getCallbackToken(nodeId);
-
-    // If matching footprints are found, send RequestFulfilledEvent
-    // with the footprint data; otherwise send RequestRejectedEvent.
-    if (footprints.length > 0) {
-
-      await this.postEvent(
-        callbackUrl, {
-          type: EventTypes.RequestFulfilled,
-          specversion: '1.0',
-          id: crypto.randomUUID(),
-          source: `${config.DIRECTORY_API}/api/nodes/${nodeId}`,
-          time: new Date().toISOString(),
-          data: {
-            requestEventId,
-            pfs: footprints,
-          },
-        } as RequestFulfilledEvent, 
-        authToken
-      );
-      logger.info(
-        { nodeId, requestEventId, matchCount: footprints.length },
-        'Sent RequestFulfilledEvent callback'
-      );
-    } else {
-      
-      await this.postEvent(
-        callbackUrl, {
-          type: EventTypes.RequestRejected,
-          specversion: '1.0',
-          id: crypto.randomUUID(),
-          source: `${config.DIRECTORY_API}/api/nodes/${nodeId}`,
-          time: new Date().toISOString(),
-          data: {
-            requestEventId,
-            error: {
-              code: 'NotFound',
-              message: 'The requested footprint could not be found.',
-            },
-          },
-        } as RequestRejectedEvent, 
-        authToken 
-      );
-      logger.info(
-        { nodeId, requestEventId },
-        'Sent RequestRejectedEvent callback'
-      );
-    }
-  }
-
-  /**
-   * Obtain an auth token for making callbacks to the conformance service.
-   * Uses the first outgoing accepted connection's credentials from this node.
-   */
-  private async getCallbackToken(nodeId: number): Promise<string> {
-    try {
-      const connection = await this.db
-        .selectFrom('connections')
-        .select(['clientId', 'clientSecret'])
-        .where('fromNodeId', '=', nodeId)
-        .where('status', '=', 'accepted')
-        .limit(1)
-        .executeTakeFirst();
-
-      if (!connection) {
-        logger.warn({ nodeId }, 'No outgoing connection found for callback auth');
-        return '';
-      }
-
-      // Decrypt the client secret (base64-encoded)
-      const clientSecret = Buffer.from(connection.clientSecret, 'base64').toString('utf-8');
-
-      // Authenticate against the conformance service auth endpoint
-      const authUrl = `${config.CONFORMANCE_API_INTERNAL}/auth/token`;
-      const basicAuth = Buffer.from(
-        `${connection.clientId}:${clientSecret}`
-      ).toString('base64');
-
-      const authResponse = await fetch(authUrl, {
-        method: 'POST',
-        headers: {
-          Authorization: `Basic ${basicAuth}`,
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-        body: 'grant_type=client_credentials',
-      });
-
-      if (authResponse.ok) {
-        const tokenData = (await authResponse.json()) as { access_token: string };
-        return tokenData.access_token;
-      }
-
-      logger.warn(
-        { nodeId, status: authResponse.status },
-        'Failed to obtain callback auth token'
-      );
-      return '';
-    } catch (err) {
-      logger.warn(
-        { nodeId, error: (err as Error).message },
-        'Error obtaining callback auth token'
-      );
-      return '';
-    }
+    logger.info({ nodeId, requestEventId, fromNodeId }, 'Incoming PCF request saved to inbox');
   }
 
   /**

--- a/apps/api/src/services/internal-node-pact-service.ts
+++ b/apps/api/src/services/internal-node-pact-service.ts
@@ -149,36 +149,27 @@ export class InternalNodePactService {
             .execute();
         }
         // Persist the received PCFs into this node's product_footprints so they
-        // appear in the node's PCF records. Select first to decide insert vs update,
-        // matching on (node_id, data->>'id') — the unique index
-        // product_footprints_node_pact_id_key enforces no duplicate PACT IDs per node.
+        // appear in the node's PCF records. The composite PK (id, node_id) prevents
+        // duplicates — use ON CONFLICT to upsert.
         if (pfs && pfs.length > 0) {
           for (const pf of pfs) {
             if (!pf?.id) continue;
-            const existing = await this.db
-              .selectFrom('product_footprints')
-              .select('id')
-              .where('nodeId', '=', nodeId)
-              .where(sql`data->>'id'`, '=', pf.id)
-              .executeTakeFirst();
-
-            if (existing) {
-              await this.db
-                .updateTable('product_footprints')
-                .set({ data: pf as unknown as Record<string, unknown>, updatedAt: new Date() })
-                .where('id', '=', existing.id)
-                .execute();
-            } else {
-              await this.db
-                .insertInto('product_footprints')
-                .values({
-                  nodeId,
+            await this.db
+              .insertInto('product_footprints')
+              .values({
+                id: pf.id,
+                nodeId,
+                data: pf as unknown as Record<string, unknown>,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+              })
+              .onConflict((oc) =>
+                oc.columns(['id', 'nodeId']).doUpdateSet({
                   data: pf as unknown as Record<string, unknown>,
-                  createdAt: new Date(),
                   updatedAt: new Date(),
                 })
-                .execute();
-            }
+              )
+              .execute();
           }
           logger.info({ nodeId, requestEventId, count: pfs.length }, 'PCFs from fulfilled request saved to node records');
         }

--- a/apps/api/src/services/pcf-request-service.test.ts
+++ b/apps/api/src/services/pcf-request-service.test.ts
@@ -503,9 +503,11 @@ describe('PcfRequestService', () => {
   // fulfill()
   // ──────────────────────────────────────────────────
   describe('fulfill()', () => {
+    // fromNodeId=null skips the local-node direct-write path, keeping most tests isolated.
+    // Tests that cover the direct-write path use a separate fixture with a known fromNodeId.
     const mockIncomingRequest = {
       id: 10,
-      fromNodeId: 888,
+      fromNodeId: null,
       targetNodeId: nodeId,
       requestEventId: 'req-ev-001',
       source: `${DIRECTORY_API}/api/nodes/888`,
@@ -699,6 +701,88 @@ describe('PcfRequestService', () => {
       await expect(
         service.fulfill(otherOrgContext, nodeId, 10, [ss23LaptopDbId])
       ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('writes PCFs directly into the requester node product_footprints when fromNodeId is a local node (new insert)', async () => {
+      // Reproduces the real scenario:
+      // silversurfer23 fulfills a request from galactus. HTTP callback fails because
+      // no reverse connection exists for auth. The fix: detect that galactus is a local
+      // node and insert directly into its product_footprints.
+      const localFromNodeId = 14; // galactus
+      const localRequest = { ...mockIncomingRequest, fromNodeId: localFromNodeId };
+      jest.clearAllMocks();
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ access_token: 'token' }) })
+        .mockResolvedValueOnce({ ok: true, text: async () => '' });
+
+      nodeService.get.mockResolvedValueOnce(mockFromNode as any);
+      dbMocks.executors.executeTakeFirst
+        .mockResolvedValueOnce(localRequest)          // load pcf_request
+        .mockResolvedValueOnce(mockReverseConnection) // getCallbackToken: reverse connection
+        .mockResolvedValueOnce({ id: localFromNodeId }) // node existence check
+        .mockResolvedValueOnce(null);                 // no existing product_footprints row
+      dbMocks.executors.execute
+        .mockResolvedValueOnce([mockFootprintRow])    // footprint lookup
+        .mockResolvedValueOnce(undefined)             // UPDATE pcf_requests
+        .mockResolvedValueOnce(undefined);            // INSERT product_footprints
+
+      await service.fulfill(adminContext, nodeId, 10, [ss23LaptopDbId]);
+
+      // INSERT into product_footprints for the requester node
+      const insertCalls = dbMocks.db.insertInto.mock.calls.filter(
+        (c) => c[0] === 'product_footprints'
+      );
+      expect(insertCalls).toHaveLength(1);
+      const insertValues = dbMocks.queryChain.values.mock.calls.find(
+        () => true
+      );
+      expect(insertValues).toBeDefined();
+      expect(insertValues![0].nodeId).toBe(localFromNodeId);
+    });
+
+    it('updates existing product_footprints row for requester node when PCF already present', async () => {
+      const localFromNodeId = 14;
+      const localRequest = { ...mockIncomingRequest, fromNodeId: localFromNodeId };
+      jest.clearAllMocks();
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ access_token: 'token' }) })
+        .mockResolvedValueOnce({ ok: true, text: async () => '' });
+
+      nodeService.get.mockResolvedValueOnce(mockFromNode as any);
+      dbMocks.executors.executeTakeFirst
+        .mockResolvedValueOnce(localRequest)
+        .mockResolvedValueOnce(mockReverseConnection)
+        .mockResolvedValueOnce({ id: localFromNodeId })      // node exists
+        .mockResolvedValueOnce({ id: 'existing-fp-uuid' });  // existing footprint row
+      dbMocks.executors.execute
+        .mockResolvedValueOnce([mockFootprintRow])
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce(undefined);
+
+      await service.fulfill(adminContext, nodeId, 10, [ss23LaptopDbId]);
+
+      // updateTable called for product_footprints
+      const updateCalls = dbMocks.db.updateTable.mock.calls.map((c) => c[0]);
+      expect(updateCalls).toContain('product_footprints');
+    });
+
+    it('skips direct-write when fromNodeId is null (external requester)', async () => {
+      // mockIncomingRequest already has fromNodeId=null
+      nodeService.get.mockResolvedValueOnce(mockFromNode as any);
+      dbMocks.executors.executeTakeFirst
+        .mockResolvedValueOnce(mockIncomingRequest)
+        .mockResolvedValueOnce(mockReverseConnection);
+      dbMocks.executors.execute
+        .mockResolvedValueOnce([mockFootprintRow])
+        .mockResolvedValueOnce(undefined);
+
+      await service.fulfill(adminContext, nodeId, 10, [ss23LaptopDbId]);
+
+      // No insert into product_footprints
+      const insertCalls = dbMocks.db.insertInto.mock.calls.filter(
+        (c) => c[0] === 'product_footprints'
+      );
+      expect(insertCalls).toHaveLength(0);
     });
   });
 

--- a/apps/api/src/services/pcf-request-service.test.ts
+++ b/apps/api/src/services/pcf-request-service.test.ts
@@ -740,7 +740,7 @@ describe('PcfRequestService', () => {
       expect(insertValues![0].nodeId).toBe(localFromNodeId);
     });
 
-    it('updates existing product_footprints row for requester node when PCF already present', async () => {
+    it('upserts product_footprints for requester node when PCF already present', async () => {
       const localFromNodeId = 14;
       const localRequest = { ...mockIncomingRequest, fromNodeId: localFromNodeId };
       jest.clearAllMocks();
@@ -752,8 +752,7 @@ describe('PcfRequestService', () => {
       dbMocks.executors.executeTakeFirst
         .mockResolvedValueOnce(localRequest)
         .mockResolvedValueOnce(mockReverseConnection)
-        .mockResolvedValueOnce({ id: localFromNodeId })      // node exists
-        .mockResolvedValueOnce({ id: 'existing-fp-uuid' });  // existing footprint row
+        .mockResolvedValueOnce({ id: localFromNodeId });      // node exists
       dbMocks.executors.execute
         .mockResolvedValueOnce([mockFootprintRow])
         .mockResolvedValueOnce(undefined)
@@ -761,9 +760,11 @@ describe('PcfRequestService', () => {
 
       await service.fulfill(adminContext, nodeId, 10, [ss23LaptopDbId]);
 
-      // updateTable called for product_footprints
-      const updateCalls = dbMocks.db.updateTable.mock.calls.map((c) => c[0]);
-      expect(updateCalls).toContain('product_footprints');
+      // Uses INSERT...ON CONFLICT (upsert) for product_footprints
+      const insertCalls = dbMocks.db.insertInto.mock.calls.filter(
+        (c) => c[0] === 'product_footprints'
+      );
+      expect(insertCalls).toHaveLength(1);
     });
 
     it('skips direct-write when fromNodeId is null (external requester)', async () => {

--- a/apps/api/src/services/pcf-request-service.test.ts
+++ b/apps/api/src/services/pcf-request-service.test.ts
@@ -1,0 +1,794 @@
+import { PcfRequestService } from './pcf-request-service';
+import { BadRequestError, ForbiddenError, NotFoundError } from '@src/common/errors';
+import { Role } from '@src/common/policies';
+import { createMockDatabase } from '../common/mock-utils';
+import { UserContext } from './user-service';
+import { NodeService } from './node-service';
+import { NodeConnectionService } from './node-connection-service';
+
+jest.mock('@src/common/logger', () => ({
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+}));
+
+jest.mock('@src/common/config', () => ({
+  JWT_SECRET: 'test-secret',
+  DIRECTORY_API: 'http://localhost:3010',
+}));
+
+// Mock PactApiClient so no real HTTP calls are made in tests
+const mockSendRequestCreated = jest.fn().mockResolvedValue('event-id-abc123');
+jest.mock('pact-api-client', () => ({
+  PactApiClient: jest.fn().mockImplementation(() => ({
+    sendRequestCreated: mockSendRequestCreated,
+  })),
+}));
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+describe('PcfRequestService', () => {
+  let dbMocks: ReturnType<typeof createMockDatabase>;
+  let service: PcfRequestService;
+  let nodeService: jest.Mocked<Pick<NodeService, 'get'>>;
+  let nodeConnectionService: jest.Mocked<Pick<NodeConnectionService, 'verifyConnectionCredentials'>>;
+
+  const DIRECTORY_API = 'http://localhost:3010';
+  const nodeId = 5;
+  const targetNodeId = 7;
+  const connectionId = 42;
+
+  // Contexts
+  const adminContext: UserContext = {
+    organizationId: 1,
+    userId: 1,
+    email: 'admin@example.com',
+    role: Role.Administrator,
+    policies: ['manage-connections-own-nodes'],
+    status: 'enabled',
+  };
+
+  const otherOrgContext: UserContext = {
+    organizationId: 99,
+    userId: 9,
+    email: 'other@example.com',
+    role: Role.User,
+    policies: ['manage-connections-own-nodes'],
+    status: 'enabled',
+  };
+
+  // Fixtures
+  const mockFromNode = {
+    id: nodeId,
+    organizationId: 1,
+    name: 'Sender Node',
+    type: 'internal' as const,
+    status: 'active' as const,
+  };
+
+  const mockTargetNode = {
+    id: targetNodeId,
+    type: 'internal' as const,
+    apiUrl: null,
+    authBaseUrl: null,
+    scope: null,
+    audience: null,
+    resource: null,
+  };
+
+  const mockConnection = {
+    id: connectionId,
+    fromNodeId: nodeId,
+    targetNodeId,
+    clientId: 'client-abc',
+    // decryptSecret does Buffer.from(x, 'base64').toString('utf-8'), so store base64
+    clientSecret: Buffer.from('secret-xyz').toString('base64'),
+    status: 'accepted' as const,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    expiresAt: null,
+  };
+
+  const mockFilters = { productId: ['urn:gtin:1234567890123'] };
+
+  // ── Real silversurfer23 PCF fixtures (from production DB) ──────────────────
+  // These are the actual JSONB data objects stored in product_footprints.data.
+  // Each fixture pair: dbRowId (product_footprints.id) + pactDataId (data->>'id').
+  // These are DIFFERENT values — the bug was querying by pactDataId when we
+  // should query by dbRowId.
+
+  const ss23LaptopDbId   = '22b351ba-f84b-496a-b3d5-7c5c36cacf84'; // DB row UUID
+  const ss23SteelDbId    = 'd5b18f05-b723-48d7-97f6-96e29a8a1ec6';
+  const ss23ContainerDbId = '229e354d-082b-4750-9918-fea94e661acf';
+
+  const ss23LaptopData = {
+    id: 'd9be4477-e351-45b3-acd9-e1da05e6f633', // PACT data ID — different from DB row UUID above
+    specVersion: '3.0.0',
+    version: 1,
+    created: '2023-07-01T00:00:00Z',
+    status: 'Active',
+    validityPeriodStart: '2023-01-15T10:15:30Z',
+    validityPeriodEnd: '2025-12-31T00:00:00Z',
+    companyName: 'Example Company Inc.',
+    companyIds: ['urn:uuid:12345678-1234-1234-1234-123456789012'],
+    productDescription: 'Exemplary Laptop Model X',
+    productIds: ['urn:gtin:12345678'],
+    productNameCompany: 'Laptop Model X',
+    productClassifications: ['urn:pact:productclassification:un-cpc:452'],
+    pcf: {
+      geographyCountry: 'US',
+      declaredUnitOfMeasurement: 'kilogram',
+      declaredUnitAmount: '1.0',
+      referencePeriodStart: '2022-01-01T00:00:00Z',
+      referencePeriodEnd: '2022-12-31T23:59:59Z',
+      pcfExcludingBiogenicUptake: '120.5',
+      pcfIncludingBiogenicUptake: '120.5',
+      fossilGhgEmissions: '115.2',
+      fossilCarbonContent: '5.3',
+      boundaryProcessesDescription: 'Cradle-to-gate',
+      ipccCharacterizationFactors: ['AR6'],
+      crossSectoralStandards: ['GHGP-Product', 'ISO14067'],
+      exemptedEmissionsPercent: '2.5',
+    },
+  };
+
+  const ss23SteelData = {
+    id: 'f8c3d912-7b4e-4a2c-b567-8e9f0a1b2c3d',
+    specVersion: '3.0.0',
+    version: 2,
+    created: '2023-08-15T00:00:00Z',
+    status: 'Active',
+    validityPeriodStart: '2023-01-15T10:15:30Z',
+    validityPeriodEnd: '2025-12-31T00:00:00Z',
+    companyName: 'Green Materials Corp',
+    companyIds: ['urn:uuid:87654321-4321-4321-4321-210987654321'],
+    productDescription: 'Sustainable Steel Beam Grade A',
+    productIds: ['urn:gtin:87654321', 'urn:ean:9876543210123'],
+    productNameCompany: 'EcoSteel Beam A500',
+    productClassifications: ['urn:pact:productclassification:un-cpc:412'],
+    pcf: {
+      geographyCountry: 'DE',
+      declaredUnitOfMeasurement: 'kilogram',
+      declaredUnitAmount: '1000.0',
+      referencePeriodStart: '2023-01-01T00:00:00Z',
+      referencePeriodEnd: '2023-06-30T23:59:59Z',
+      pcfExcludingBiogenicUptake: '450.8',
+      pcfIncludingBiogenicUptake: '420.5',
+      fossilGhgEmissions: '440.2',
+      fossilCarbonContent: '10.6',
+      boundaryProcessesDescription: 'Cradle-to-gate including iron ore mining',
+      ipccCharacterizationFactors: ['AR6'],
+      crossSectoralStandards: ['ISO14067', 'ISO14040-44'],
+      exemptedEmissionsPercent: '1.8',
+    },
+  };
+
+  const ss23ContainerData = {
+    id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+    specVersion: '3.0.0',
+    version: 1,
+    created: '2023-09-20T00:00:00Z',
+    status: 'Active',
+    validityPeriodStart: '2023-09-01T00:00:00Z',
+    validityPeriodEnd: '2024-08-31T23:59:59Z',
+    companyName: 'BioPack Solutions',
+    companyIds: ['urn:uuid:abcdef12-3456-7890-abcd-ef1234567890'],
+    productDescription: 'Compostable Food Container 500ml',
+    productIds: ['urn:gtin:55667788'],
+    productNameCompany: 'EcoContainer 500',
+    productClassifications: ['urn:pact:productclassification:un-cpc:893'],
+    pcf: {
+      geographyCountry: 'NL',
+      declaredUnitOfMeasurement: 'kilogram',
+      declaredUnitAmount: '0.025',
+      referencePeriodStart: '2023-01-01T00:00:00Z',
+      referencePeriodEnd: '2023-08-31T23:59:59Z',
+      pcfExcludingBiogenicUptake: '0.85',
+      pcfIncludingBiogenicUptake: '-0.15',
+      fossilGhgEmissions: '0.75',
+      fossilCarbonContent: '0.10',
+      boundaryProcessesDescription: 'Cradle-to-gate',
+      ipccCharacterizationFactors: ['AR5'],
+      crossSectoralStandards: ['GHGP-Product'],
+      exemptedEmissionsPercent: '3.2',
+    },
+  };
+
+  // DB rows as returned by product_footprints SELECT
+  const ss23LaptopRow    = { id: ss23LaptopDbId,    nodeId, data: ss23LaptopData };
+  const ss23SteelRow     = { id: ss23SteelDbId,     nodeId, data: ss23SteelData };
+  const ss23ContainerRow = { id: ss23ContainerDbId, nodeId, data: ss23ContainerData };
+
+  const mockInsertedRow = {
+    id: 1,
+    fromNodeId: nodeId,
+    targetNodeId,
+    connectionId,
+    requestEventId: 'event-id-abc123',
+    source: null,
+    filters: mockFilters,
+    status: 'pending' as const,
+    resultCount: null,
+    fulfilledFootprintIds: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    dbMocks = createMockDatabase();
+    nodeService = { get: jest.fn() } as any;
+    nodeConnectionService = { verifyConnectionCredentials: jest.fn() } as any;
+    service = new PcfRequestService(
+      dbMocks.db as any,
+      nodeService as any,
+      nodeConnectionService as any,
+      DIRECTORY_API
+    );
+  });
+
+  // ──────────────────────────────────────────────────
+  // create()
+  // ──────────────────────────────────────────────────
+  describe('create()', () => {
+    it('sends RequestCreatedEvent and persists the outgoing request', async () => {
+      dbMocks.executors.executeTakeFirst.mockResolvedValueOnce(mockConnection); // load connection
+      nodeService.get.mockResolvedValueOnce(mockFromNode as any);              // access check
+      dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce(mockTargetNode);  // target node
+      dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce(mockInsertedRow); // insert
+
+      const result = await service.create(adminContext, nodeId, {
+        connectionId,
+        filters: mockFilters,
+      });
+
+      expect(result.direction).toBe('outgoing');
+      expect(result.status).toBe('pending');
+      expect(result.requestEventId).toBe('event-id-abc123');
+      expect(result.fromNodeId).toBe(nodeId);
+      expect(result.targetNodeId).toBe(targetNodeId);
+      expect(mockSendRequestCreated).toHaveBeenCalledWith(mockFilters);
+    });
+
+    it('builds the PactApiClient with the connection credentials', async () => {
+      const { PactApiClient } = require('pact-api-client');
+      dbMocks.executors.executeTakeFirst.mockResolvedValueOnce(mockConnection);
+      nodeService.get.mockResolvedValueOnce(mockFromNode as any);
+      dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce(mockTargetNode);
+      dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce(mockInsertedRow);
+
+      await service.create(adminContext, nodeId, { connectionId, filters: mockFilters });
+
+      expect(PactApiClient).toHaveBeenCalledWith(
+        // baseUrl: no apiUrl so falls back to directory internal URL
+        `${DIRECTORY_API}/api/nodes/${targetNodeId}`,
+        'client-abc',
+        'secret-xyz', // decrypted from base64
+        `${DIRECTORY_API}/api/nodes/${nodeId}`,
+        expect.any(Object)
+      );
+    });
+
+    it('uses the node apiUrl when present', async () => {
+      const { PactApiClient } = require('pact-api-client');
+      const nodeWithUrl = { ...mockTargetNode, apiUrl: 'https://external.example.com/pact/' };
+      dbMocks.executors.executeTakeFirst.mockResolvedValueOnce(mockConnection);
+      nodeService.get.mockResolvedValueOnce(mockFromNode as any);
+      dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce(nodeWithUrl);
+      dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce(mockInsertedRow);
+
+      await service.create(adminContext, nodeId, { connectionId, filters: mockFilters });
+
+      expect(PactApiClient).toHaveBeenCalledWith(
+        'https://external.example.com/pact', // trailing slash stripped
+        expect.any(String),
+        expect.any(String),
+        expect.any(String),
+        expect.any(Object)
+      );
+    });
+
+    it('throws BadRequestError when no filters are provided', async () => {
+      await expect(
+        service.create(adminContext, nodeId, { connectionId, filters: {} })
+      ).rejects.toThrow(BadRequestError);
+    });
+
+    it('throws NotFoundError when connection does not exist or is not accepted', async () => {
+      dbMocks.executors.executeTakeFirst.mockResolvedValueOnce(null);
+
+      await expect(
+        service.create(adminContext, nodeId, { connectionId, filters: mockFilters })
+      ).rejects.toThrow(NotFoundError);
+    });
+
+    it('throws BadRequestError when the node is the targetNodeId (incoming connection)', async () => {
+      // fromNodeId is someone else — this node is the target, not the initiator
+      const incomingConnection = { ...mockConnection, fromNodeId: 999, targetNodeId: nodeId };
+      dbMocks.executors.executeTakeFirst.mockResolvedValueOnce(incomingConnection);
+
+      await expect(
+        service.create(adminContext, nodeId, { connectionId, filters: mockFilters })
+      ).rejects.toThrow(BadRequestError);
+    });
+
+    it('throws BadRequestError when the connection belongs to an unrelated node', async () => {
+      const unrelatedConnection = { ...mockConnection, fromNodeId: 888, targetNodeId: 999 };
+      dbMocks.executors.executeTakeFirst.mockResolvedValueOnce(unrelatedConnection);
+
+      await expect(
+        service.create(adminContext, nodeId, { connectionId, filters: mockFilters })
+      ).rejects.toThrow(BadRequestError);
+    });
+
+    it('throws ForbiddenError when user belongs to a different organization', async () => {
+      dbMocks.executors.executeTakeFirst.mockResolvedValueOnce(mockConnection);
+      nodeService.get.mockResolvedValueOnce(mockFromNode as any); // org 1
+
+      await expect(
+        service.create(otherOrgContext /* org 99 */, nodeId, { connectionId, filters: mockFilters })
+      ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('propagates errors from PactApiClient (e.g. auth failure)', async () => {
+      mockSendRequestCreated.mockRejectedValueOnce(
+        new Error('Authentication failed: 401 Unauthorized')
+      );
+      dbMocks.executors.executeTakeFirst.mockResolvedValueOnce(mockConnection);
+      nodeService.get.mockResolvedValueOnce(mockFromNode as any);
+      dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce(mockTargetNode);
+
+      await expect(
+        service.create(adminContext, nodeId, { connectionId, filters: mockFilters })
+      ).rejects.toThrow('Authentication failed');
+    });
+
+    it('succeeds even when the target node (shared DB) already inserted the incoming row — ON CONFLICT DO UPDATE path', async () => {
+      // Reproduces the "duplicate key value violates unique constraint pcf_requests_request_event_id_key"
+      // bug that occurs when both nodes share the same directory service instance:
+      //   1. create() sends the RequestCreatedEvent to the target's /3/events
+      //   2. target's handleRequestCreatedEvent() inserts the incoming row (requestEventId = X)
+      //   3. create() then tries to insert the outgoing row with the same requestEventId = X
+      // The ON CONFLICT DO UPDATE clause handles this by updating connectionId on the existing row.
+      // The mock simulates the DB returning the merged row (same as regular insert path).
+      dbMocks.executors.executeTakeFirst.mockResolvedValueOnce(mockConnection);
+      nodeService.get.mockResolvedValueOnce(mockFromNode as any);
+      dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce(mockTargetNode);
+      // Simulate DB returning the upserted (conflict-updated) row
+      dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce(mockInsertedRow);
+
+      const result = await service.create(adminContext, nodeId, { connectionId, filters: mockFilters });
+
+      expect(result.direction).toBe('outgoing');
+      expect(result.requestEventId).toBe('event-id-abc123');
+      expect(result.connectionId).toBe(connectionId);
+    });
+  });
+
+  // ──────────────────────────────────────────────────
+  // list() — direction and access control
+  // ──────────────────────────────────────────────────
+  describe('list() — direction and access', () => {
+    const outgoingRow = {
+      id: 1,
+      fromNodeId: nodeId,
+      targetNodeId,
+      connectionId,
+      requestEventId: 'ev-out',
+      source: null,
+      filters: mockFilters,
+      status: 'pending',
+      resultCount: null,
+      fulfilledFootprintIds: null,
+      fromNodeName: 'Sender Node',
+      targetNodeName: 'Target Node',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    const incomingRow = {
+      ...outgoingRow,
+      id: 2,
+      fromNodeId: 888,
+      targetNodeId: nodeId,
+      requestEventId: 'ev-in',
+      fromNodeName: 'External Node',
+      targetNodeName: 'Sender Node',
+    };
+
+    it('sets direction=outgoing for requests sent by this node', async () => {
+      nodeService.get.mockResolvedValueOnce(mockFromNode as any);
+      dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce({ total: 2 });
+      dbMocks.executors.execute.mockResolvedValueOnce([outgoingRow, incomingRow]);
+      // incoming pending fulfillable check
+      dbMocks.executors.executeTakeFirst.mockResolvedValueOnce(null);
+
+      const result = await service.list(adminContext, nodeId);
+
+      expect(result.data).toHaveLength(2);
+      expect(result.data[0].direction).toBe('outgoing');
+      expect(result.data[1].direction).toBe('incoming');
+    });
+
+    it('throws ForbiddenError when user belongs to a different organization', async () => {
+      nodeService.get.mockResolvedValueOnce(mockFromNode as any);
+
+      await expect(service.list(otherOrgContext, nodeId)).rejects.toThrow(ForbiddenError);
+    });
+  });
+
+  // ──────────────────────────────────────────────────
+  // list() — fulfillable checks with real filter types
+  // ──────────────────────────────────────────────────
+  describe('list() — fulfillable check with various filter types', () => {
+    const makeIncomingRow = (filters: Record<string, unknown>) => ({
+      id: 2,
+      fromNodeId: 888,
+      targetNodeId: nodeId,
+      connectionId,
+      requestEventId: 'ev-in',
+      source: `${DIRECTORY_API}/api/nodes/888`,
+      filters,
+      status: 'pending',
+      resultCount: null,
+      fulfilledFootprintIds: null,
+      fromNodeName: 'Requester Node',
+      targetNodeName: 'silversurfer23',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    it('fulfillable=true for productId filter when node has a matching footprint', async () => {
+      const row = makeIncomingRow({ productId: ['urn:gtin:12345678'] });
+      nodeService.get.mockResolvedValueOnce(mockFromNode as any);
+      dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce({ total: 1 });
+      dbMocks.executors.execute.mockResolvedValueOnce([row]);
+      dbMocks.executors.executeTakeFirst.mockResolvedValueOnce({ id: ss23LaptopDbId }); // match found
+
+      const result = await service.list(adminContext, nodeId);
+      expect(result.data[0].fulfillable).toBe(true);
+    });
+
+    it('fulfillable=false for productId filter when node has no matching footprint', async () => {
+      const row = makeIncomingRow({ productId: ['urn:gtin:99999999'] }); // non-existent
+      nodeService.get.mockResolvedValueOnce(mockFromNode as any);
+      dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce({ total: 1 });
+      dbMocks.executors.execute.mockResolvedValueOnce([row]);
+      dbMocks.executors.executeTakeFirst.mockResolvedValueOnce(null); // no match
+
+      const result = await service.list(adminContext, nodeId);
+      expect(result.data[0].fulfillable).toBe(false);
+    });
+
+    it('fulfillable=true for geography-only filter when node has any footprints', async () => {
+      // No productId filter — fulfillable check uses ANY footprint heuristic
+      const row = makeIncomingRow({ geography: ['US'] });
+      nodeService.get.mockResolvedValueOnce(mockFromNode as any);
+      dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce({ total: 1 });
+      dbMocks.executors.execute.mockResolvedValueOnce([row]);
+      dbMocks.executors.executeTakeFirst.mockResolvedValueOnce({ id: ss23LaptopDbId }); // has footprints
+
+      const result = await service.list(adminContext, nodeId);
+      expect(result.data[0].fulfillable).toBe(true);
+    });
+
+    it('fulfillable=false for geography-only filter when node has no footprints at all', async () => {
+      const row = makeIncomingRow({ geography: ['JP'] });
+      nodeService.get.mockResolvedValueOnce(mockFromNode as any);
+      dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce({ total: 1 });
+      dbMocks.executors.execute.mockResolvedValueOnce([row]);
+      dbMocks.executors.executeTakeFirst.mockResolvedValueOnce(null);
+
+      const result = await service.list(adminContext, nodeId);
+      expect(result.data[0].fulfillable).toBe(false);
+    });
+
+    it('does not set fulfillable on outgoing rows', async () => {
+      const outgoing = makeIncomingRow({ productId: ['urn:gtin:12345678'] });
+      outgoing.fromNodeId = nodeId;      // make it outgoing
+      outgoing.targetNodeId = 888;
+      nodeService.get.mockResolvedValueOnce(mockFromNode as any);
+      dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce({ total: 1 });
+      dbMocks.executors.execute.mockResolvedValueOnce([outgoing]);
+
+      const result = await service.list(adminContext, nodeId);
+      expect(result.data[0].direction).toBe('outgoing');
+      expect(result.data[0].fulfillable).toBeUndefined();
+    });
+  });
+
+  // ──────────────────────────────────────────────────
+  // fulfill()
+  // ──────────────────────────────────────────────────
+  describe('fulfill()', () => {
+    const mockIncomingRequest = {
+      id: 10,
+      fromNodeId: 888,
+      targetNodeId: nodeId,
+      requestEventId: 'req-ev-001',
+      source: `${DIRECTORY_API}/api/nodes/888`,
+      status: 'pending',
+      filters: { geography: ['US'] },
+    };
+
+    // Use the real silversurfer23 US laptop row — DB row id ≠ PACT data id
+    const mockFootprintRow = { data: ss23LaptopData };
+
+    const mockReverseConnection = {
+      clientId: 'cb-client',
+      clientSecret: Buffer.from('cb-secret').toString('base64'),
+    };
+
+    beforeEach(() => {
+      // getCallbackToken: reverse connection + auth token fetch
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ access_token: 'callback-token-xyz' }),
+        })
+        .mockResolvedValueOnce({ ok: true }); // callback POST
+    });
+
+    it('queries footprints by DB row id column, not by PACT data id field', async () => {
+      // This test verifies the fix for the bug where fulfill() was querying
+      // `data->>'id'` (the PACT JSON field) instead of the `id` DB column.
+      // The FulfillPcfRequestForm sends DB row UUIDs; the PACT data id inside
+      // the JSONB is a completely different value.
+      nodeService.get.mockResolvedValueOnce(mockFromNode as any);
+      dbMocks.executors.executeTakeFirst
+        .mockResolvedValueOnce(mockIncomingRequest)
+        .mockResolvedValueOnce(mockReverseConnection);
+      dbMocks.executors.execute
+        .mockResolvedValueOnce([mockFootprintRow])  // footprint lookup
+        .mockResolvedValueOnce(undefined);          // UPDATE
+
+      await service.fulfill(adminContext, nodeId, 10, [ss23LaptopDbId]);
+
+      // Verify the footprint lookup used the DB row `id` column with 'in' operator,
+      // NOT the `data->>'id'` JSON field (which would be ss23LaptopData.id = 'd9be4477...')
+      const whereCalls = dbMocks.queryChain.where.mock.calls;
+      const footprintIdLookup = whereCalls.find(
+        (args) => args[0] === 'id' && args[1] === 'in'
+      );
+      expect(footprintIdLookup).toBeDefined();
+      expect(footprintIdLookup![2]).toEqual([ss23LaptopDbId]);
+    });
+
+    it('the PACT data id (inside JSON) would NOT find footprints via DB row id lookup', async () => {
+      // Simulates what the OLD buggy code would have experienced:
+      // passing the PACT data id (ss23LaptopData.id) instead of the DB row UUID.
+      // The mock returns empty because nothing matches — proving the bug.
+      nodeService.get.mockResolvedValueOnce(mockFromNode as any);
+      dbMocks.executors.executeTakeFirst.mockResolvedValueOnce(mockIncomingRequest);
+      dbMocks.executors.execute.mockResolvedValueOnce([]); // no match — this is what the bug caused
+
+      await expect(
+        service.fulfill(adminContext, nodeId, 10, [ss23LaptopData.id]) // PACT data id, not DB id
+      ).rejects.toThrow(NotFoundError);
+    });
+
+    it('sends RequestFulfilledEvent with the PCF data from the matched footprints', async () => {
+      nodeService.get.mockResolvedValueOnce(mockFromNode as any);
+      dbMocks.executors.executeTakeFirst
+        .mockResolvedValueOnce(mockIncomingRequest)
+        .mockResolvedValueOnce(mockReverseConnection);
+      dbMocks.executors.execute
+        .mockResolvedValueOnce([mockFootprintRow])
+        .mockResolvedValueOnce(undefined);
+
+      await service.fulfill(adminContext, nodeId, 10, [ss23LaptopDbId]);
+
+      const callbackCall = mockFetch.mock.calls.find(
+        (call) => typeof call[0] === 'string' && call[0].includes('/3/events')
+      );
+      expect(callbackCall).toBeDefined();
+      const body = JSON.parse(callbackCall![1].body);
+      expect(body.type).toBe('org.wbcsd.pact.ProductFootprint.RequestFulfilledEvent.3');
+      expect(body.data.requestEventId).toBe('req-ev-001');
+      expect(body.data.pfs).toHaveLength(1);
+      expect(body.data.pfs[0].id).toBe(ss23LaptopData.id);
+    });
+
+    it('stores fulfilledFootprintIds as a JSON string (not native array) to satisfy the jsonb column', async () => {
+      // Reproduces: "invalid input syntax for type json" — PostgreSQL rejects a native
+      // JS array passed as jsonb because pg sends it as "{uuid...}" (array literal)
+      // instead of the valid JSON format ["uuid..."]. The fix is JSON.stringify().
+      nodeService.get.mockResolvedValueOnce(mockFromNode as any);
+      dbMocks.executors.executeTakeFirst
+        .mockResolvedValueOnce(mockIncomingRequest)
+        .mockResolvedValueOnce(mockReverseConnection);
+      dbMocks.executors.execute
+        .mockResolvedValueOnce([mockFootprintRow])
+        .mockResolvedValueOnce(undefined);
+
+      await service.fulfill(adminContext, nodeId, 10, [ss23LaptopDbId]);
+
+      const setCalls = dbMocks.queryChain.set.mock.calls;
+      const updateCall = setCalls.find((args) => args[0]?.status === 'fulfilled');
+      expect(updateCall).toBeDefined();
+      // Must be a JSON string, not a raw array
+      expect(typeof updateCall![0].fulfilledFootprintIds).toBe('string');
+      expect(JSON.parse(updateCall![0].fulfilledFootprintIds)).toEqual([ss23LaptopDbId]);
+    });
+
+    it('can fulfill with multiple footprints (e.g. DE steel + NL container)', async () => {
+      nodeService.get.mockResolvedValueOnce(mockFromNode as any);
+      dbMocks.executors.executeTakeFirst
+        .mockResolvedValueOnce(mockIncomingRequest)
+        .mockResolvedValueOnce(mockReverseConnection);
+      dbMocks.executors.execute
+        .mockResolvedValueOnce([{ data: ss23SteelData }, { data: ss23ContainerData }])
+        .mockResolvedValueOnce(undefined);
+
+      await service.fulfill(adminContext, nodeId, 10, [ss23SteelDbId, ss23ContainerDbId]);
+
+      const callbackCall = mockFetch.mock.calls.find(
+        (call) => typeof call[0] === 'string' && call[0].includes('/3/events')
+      );
+      expect(callbackCall).toBeDefined();
+      const body = JSON.parse(callbackCall![1].body);
+      expect(body.data.pfs).toHaveLength(2);
+    });
+
+    it('marks fulfilled even when callback returns non-OK (best-effort)', async () => {
+      jest.clearAllMocks();
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ access_token: 'token' }) })
+        .mockResolvedValueOnce({ ok: false, status: 503, text: async () => 'Service Unavailable' });
+
+      nodeService.get.mockResolvedValueOnce(mockFromNode as any);
+      dbMocks.executors.executeTakeFirst
+        .mockResolvedValueOnce(mockIncomingRequest)
+        .mockResolvedValueOnce(mockReverseConnection);
+      dbMocks.executors.execute
+        .mockResolvedValueOnce([mockFootprintRow])
+        .mockResolvedValueOnce(undefined);
+
+      await expect(
+        service.fulfill(adminContext, nodeId, 10, [ss23LaptopDbId])
+      ).resolves.toBeUndefined();
+    });
+
+    it('marks fulfilled even when source URL is null (no callback sent)', async () => {
+      jest.clearAllMocks();
+      const noSourceRequest = { ...mockIncomingRequest, source: null };
+
+      nodeService.get.mockResolvedValueOnce(mockFromNode as any);
+      dbMocks.executors.executeTakeFirst.mockResolvedValueOnce(noSourceRequest);
+      dbMocks.executors.execute
+        .mockResolvedValueOnce([mockFootprintRow])
+        .mockResolvedValueOnce(undefined);
+
+      await expect(
+        service.fulfill(adminContext, nodeId, 10, [ss23LaptopDbId])
+      ).resolves.toBeUndefined();
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestError when footprintIds is empty', async () => {
+      await expect(
+        service.fulfill(adminContext, nodeId, 10, [])
+      ).rejects.toThrow(BadRequestError);
+    });
+
+    it('throws NotFoundError when no pending incoming request found', async () => {
+      nodeService.get.mockResolvedValueOnce(mockFromNode as any);
+      dbMocks.executors.executeTakeFirst.mockResolvedValueOnce(null);
+
+      await expect(
+        service.fulfill(adminContext, nodeId, 10, [ss23LaptopDbId])
+      ).rejects.toThrow(NotFoundError);
+    });
+
+    it('throws NotFoundError when DB row IDs do not match any footprint', async () => {
+      nodeService.get.mockResolvedValueOnce(mockFromNode as any);
+      dbMocks.executors.executeTakeFirst.mockResolvedValueOnce(mockIncomingRequest);
+      dbMocks.executors.execute.mockResolvedValueOnce([]); // nothing found
+
+      await expect(
+        service.fulfill(adminContext, nodeId, 10, ['00000000-0000-0000-0000-000000000000'])
+      ).rejects.toThrow(NotFoundError);
+    });
+
+    it('throws ForbiddenError when user lacks permission', async () => {
+      nodeService.get.mockResolvedValueOnce(mockFromNode as any);
+
+      await expect(
+        service.fulfill(otherOrgContext, nodeId, 10, [ss23LaptopDbId])
+      ).rejects.toThrow(ForbiddenError);
+    });
+  });
+
+  // ──────────────────────────────────────────────────
+  // reject()
+  // ──────────────────────────────────────────────────
+  describe('reject()', () => {
+    const mockIncomingRequest = {
+      id: 11,
+      fromNodeId: 888,
+      targetNodeId: nodeId,
+      requestEventId: 'req-ev-002',
+      source: `${DIRECTORY_API}/api/nodes/888`,
+      status: 'pending',
+    };
+
+    const mockReverseConnection = {
+      clientId: 'cb-client',
+      clientSecret: Buffer.from('cb-secret').toString('base64'),
+    };
+
+    beforeEach(() => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ access_token: 'callback-token' }),
+        })
+        .mockResolvedValueOnce({ ok: true }); // callback POST
+    });
+
+    it('sends RequestRejectedEvent and marks row as rejected', async () => {
+      nodeService.get.mockResolvedValueOnce(mockFromNode as any);
+      dbMocks.executors.executeTakeFirst
+        .mockResolvedValueOnce(mockIncomingRequest)
+        .mockResolvedValueOnce(mockReverseConnection);
+      dbMocks.executors.execute.mockResolvedValueOnce(undefined); // UPDATE
+
+      await service.reject(adminContext, nodeId, 11);
+
+      const callbackCall = mockFetch.mock.calls.find(
+        (call) => typeof call[0] === 'string' && call[0].includes('/3/events')
+      );
+      expect(callbackCall).toBeDefined();
+      const body = JSON.parse(callbackCall![1].body);
+      expect(body.type).toBe('org.wbcsd.pact.ProductFootprint.RequestRejectedEvent.3');
+      expect(body.data.requestEventId).toBe('req-ev-002');
+    });
+
+    it('marks rejected even when callback returns non-OK (best-effort)', async () => {
+      jest.clearAllMocks();
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ access_token: 'token' }),
+        })
+        .mockResolvedValueOnce({ ok: false, status: 503, text: async () => 'error' });
+
+      nodeService.get.mockResolvedValueOnce(mockFromNode as any);
+      dbMocks.executors.executeTakeFirst
+        .mockResolvedValueOnce(mockIncomingRequest)
+        .mockResolvedValueOnce(mockReverseConnection);
+      dbMocks.executors.execute.mockResolvedValueOnce(undefined);
+
+      await expect(service.reject(adminContext, nodeId, 11)).resolves.toBeUndefined();
+    });
+
+    it('marks rejected even when source URL is null', async () => {
+      jest.clearAllMocks();
+      const noSourceRequest = { ...mockIncomingRequest, source: null };
+
+      nodeService.get.mockResolvedValueOnce(mockFromNode as any);
+      dbMocks.executors.executeTakeFirst.mockResolvedValueOnce(noSourceRequest);
+      dbMocks.executors.execute.mockResolvedValueOnce(undefined);
+
+      await expect(service.reject(adminContext, nodeId, 11)).resolves.toBeUndefined();
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFoundError when no pending incoming request found', async () => {
+      nodeService.get.mockResolvedValueOnce(mockFromNode as any);
+      dbMocks.executors.executeTakeFirst.mockResolvedValueOnce(null);
+
+      await expect(service.reject(adminContext, nodeId, 11)).rejects.toThrow(NotFoundError);
+    });
+
+    it('throws ForbiddenError when user lacks permission', async () => {
+      nodeService.get.mockResolvedValueOnce(mockFromNode as any);
+
+      await expect(service.reject(otherOrgContext, nodeId, 11)).rejects.toThrow(ForbiddenError);
+    });
+  });
+});

--- a/apps/api/src/services/pcf-request-service.ts
+++ b/apps/api/src/services/pcf-request-service.ts
@@ -1,4 +1,4 @@
-import { Kysely } from 'kysely';
+import { Kysely, sql } from 'kysely';
 import { Database } from '@src/database/types';
 import { BadRequestError, ForbiddenError, NotFoundError } from '@src/common/errors';
 import { ListQuery, ListResult } from '@src/common/list-query';
@@ -6,18 +6,24 @@ import { UserContext } from './user-service';
 import { NodeService } from './node-service';
 import { NodeConnectionService } from './node-connection-service';
 import { PactApiClient, FootprintFilters } from 'pact-api-client';
+import { EventTypes } from 'pact-data-model/v3_0';
+import logger from '@src/common/logger';
 
 export interface PcfRequestData {
   id: number;
-  fromNodeId: number;
+  fromNodeId: number | null;
   fromNodeName?: string;
   targetNodeId: number;
   targetNodeName?: string;
-  connectionId: number;
+  connectionId: number | null;
   requestEventId: string;
+  source: string | null;
   filters: FootprintFilters;
   status: 'pending' | 'fulfilled' | 'rejected';
   resultCount: number | null;
+  fulfilledFootprintIds: unknown[] | null;
+  direction: 'outgoing' | 'incoming';
+  fulfillable?: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -69,11 +75,15 @@ export class PcfRequestService {
       throw new NotFoundError('Connection not found or not active');
     }
 
+    // Only the initiating side (fromNodeId) can send PCF requests via a connection.
+    // The connection credentials authenticate fromNodeId to targetNodeId's PACT API;
+    // they cannot be used in reverse. To send a request in the other direction,
+    // a separate outgoing connection must be created.
     if (connection.fromNodeId !== nodeId) {
       throw new BadRequestError('Connection does not belong to this node');
     }
 
-    // Check user has access to the from-node
+    // Check user has access to this node
     const fromNode = await this.nodeService.get(context, nodeId);
 
     const allowed =
@@ -115,13 +125,18 @@ export class PcfRequestService {
     // Send the RequestCreatedEvent and get back the event ID
     const requestEventId = await client.sendRequestCreated(filters);
 
-    // Persist the outgoing request
+    // Persist the outgoing request.
+    // When both nodes share the same database, the target node's event handler
+    // may have already inserted an incoming row with the same requestEventId by
+    // the time we reach this point (the HTTP call to /3/events is synchronous).
+    // On conflict, update only connectionId so the single shared row gains the
+    // outgoing context while preserving the `source` field set by the incoming insert.
     const row = await this.db
       .insertInto('pcf_requests')
       .values({
         fromNodeId: nodeId,
         targetNodeId: targetNode.id,
-        connectionId,
+        connectionId: connection.id,
         requestEventId,
         filters: filters as unknown as Record<string, unknown>,
         status: 'pending',
@@ -129,6 +144,11 @@ export class PcfRequestService {
         createdAt: new Date(),
         updatedAt: new Date(),
       })
+      .onConflict((oc) =>
+        oc.column('requestEventId').doUpdateSet((eb) => ({
+          connectionId: eb.ref('excluded.connectionId'),
+        }))
+      )
       .returningAll()
       .executeTakeFirstOrThrow();
 
@@ -136,6 +156,7 @@ export class PcfRequestService {
       ...row,
       filters: row.filters as unknown as FootprintFilters,
       fromNodeName: fromNode.name,
+      direction: 'outgoing' as const,
     };
   }
 
@@ -155,7 +176,18 @@ export class PcfRequestService {
       throw new ForbiddenError('You are not allowed to view PCF requests for this node');
     }
 
-    let qb = this.db
+    const total = (
+      await this.db
+        .selectFrom('pcf_requests')
+        .select((eb) => eb.fn.count('id').as('total'))
+        .where((eb) => eb.or([
+          eb('pcf_requests.fromNodeId', '=', nodeId),
+          eb('pcf_requests.targetNodeId', '=', nodeId),
+        ]))
+        .executeTakeFirstOrThrow()
+    ).total as number;
+
+    const rows = await this.db
       .selectFrom('pcf_requests')
       .leftJoin('nodes as fromNode', 'fromNode.id', 'pcf_requests.fromNodeId')
       .leftJoin('nodes as targetNode', 'targetNode.id', 'pcf_requests.targetNodeId')
@@ -167,33 +199,286 @@ export class PcfRequestService {
         'targetNode.name as targetNodeName',
         'pcf_requests.connectionId',
         'pcf_requests.requestEventId',
+        'pcf_requests.source',
         'pcf_requests.filters',
         'pcf_requests.status',
         'pcf_requests.resultCount',
+        'pcf_requests.fulfilledFootprintIds',
         'pcf_requests.createdAt',
         'pcf_requests.updatedAt',
       ])
-      .where('pcf_requests.fromNodeId', '=', nodeId);
+      .where((eb) => eb.or([
+        eb('pcf_requests.fromNodeId', '=', nodeId),
+        eb('pcf_requests.targetNodeId', '=', nodeId),
+      ]))
+      .orderBy('pcf_requests.createdAt', query.sortOrder || 'desc')
+      .offset(query.offset)
+      .limit(query.limit)
+      .execute();
 
-    const total = (
-      await this.db
-        .selectFrom('pcf_requests')
-        .select((eb) => eb.fn.count('id').as('total'))
-        .where('fromNodeId', '=', nodeId)
-        .executeTakeFirstOrThrow()
-    ).total as number;
-
-    qb = qb.orderBy('pcf_requests.createdAt', query.sortOrder || 'desc');
-
-    const data = await qb.offset(query.offset).limit(query.limit).execute();
-
-    return {
-      data: data.map((row) => ({
+    // Compute fulfillable for incoming pending rows
+    const data = await Promise.all(rows.map(async (row) => {
+      const direction: 'outgoing' | 'incoming' = row.fromNodeId === nodeId ? 'outgoing' : 'incoming';
+      const base: PcfRequestData = {
         ...row,
+        fromNodeName: row.fromNodeName ?? undefined,
+        targetNodeName: row.targetNodeName ?? undefined,
         filters: row.filters as unknown as FootprintFilters,
-      })) as PcfRequestData[],
-      pagination: query.pagination(total),
-    };
+        fulfilledFootprintIds: row.fulfilledFootprintIds as unknown[] | null,
+        direction,
+      };
+
+      if (direction === 'incoming' && row.status === 'pending') {
+        const filters = base.filters;
+        const productIds = filters.productId ?? [];
+        if (productIds.length > 0) {
+          const match = await this.db
+            .selectFrom('product_footprints')
+            .select('id')
+            .where('nodeId', '=', nodeId)
+            .where((eb) => eb.or(
+              productIds.map((pid) =>
+                sql<boolean>`${eb.ref('data')}->'productIds' @> ${sql`${JSON.stringify([pid])}::jsonb`}`
+              )
+            ))
+            .limit(1)
+            .executeTakeFirst();
+          base.fulfillable = !!match;
+        } else {
+          // No productId filter — check if node has any footprints
+          const any = await this.db
+            .selectFrom('product_footprints')
+            .select('id')
+            .where('nodeId', '=', nodeId)
+            .limit(1)
+            .executeTakeFirst();
+          base.fulfillable = !!any;
+        }
+      }
+
+      return base;
+    }));
+
+    return { data, pagination: query.pagination(total) };
+  }
+
+  async fulfill(
+    context: UserContext,
+    nodeId: number,
+    requestId: number,
+    footprintIds: string[]
+  ): Promise<void> {
+    if (!footprintIds || footprintIds.length === 0) {
+      throw new BadRequestError('At least one footprint ID must be provided');
+    }
+
+    const node = await this.nodeService.get(context, nodeId);
+
+    const allowed =
+      context.policies.includes('manage-connections-all-nodes') ||
+      (context.policies.includes('manage-connections-own-nodes') &&
+        context.organizationId === node.organizationId);
+
+    if (!allowed) {
+      throw new ForbiddenError('You are not allowed to fulfill PCF requests for this node');
+    }
+
+    const request = await this.db
+      .selectFrom('pcf_requests')
+      .selectAll()
+      .where('id', '=', requestId)
+      .where('targetNodeId', '=', nodeId)
+      .where('status', '=', 'pending')
+      .executeTakeFirst();
+
+    if (!request) {
+      throw new NotFoundError('Pending incoming PCF request not found');
+    }
+
+    // Load the selected footprints by their DB row ID (product_footprints.id).
+    // The form sends DB UUIDs, NOT the PACT data ID inside the JSON blob.
+    const footprintRows = await this.db
+      .selectFrom('product_footprints')
+      .select('data')
+      .where('nodeId', '=', nodeId)
+      .where('id', 'in', footprintIds)
+      .execute();
+
+    if (footprintRows.length === 0) {
+      throw new NotFoundError('No matching footprints found');
+    }
+
+    const footprints = footprintRows.map((r) => r.data);
+
+    // Send RequestFulfilledEvent callback
+    const callbackUrl = request.source
+      ? (request.source.endsWith('/3/events') ? request.source : `${request.source.replace(/\/+$/, '')}/3/events`)
+      : null;
+
+    if (callbackUrl) {
+      const authToken = await this.getCallbackToken(nodeId, request.fromNodeId ?? null);
+      const selfSource = `${this.directoryApiBaseUrl}/api/nodes/${nodeId}`;
+
+      const event = {
+        type: EventTypes.RequestFulfilled,
+        specversion: '1.0',
+        id: crypto.randomUUID(),
+        source: selfSource,
+        time: new Date().toISOString(),
+        data: { requestEventId: request.requestEventId, pfs: footprints },
+      };
+
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      if (authToken) headers['Authorization'] = `Bearer ${authToken}`;
+
+      const response = await fetch(callbackUrl, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(event),
+      });
+
+      if (!response.ok) {
+        const body = await response.text().catch(() => '');
+        logger.warn(
+          { nodeId, requestId, status: response.status, body },
+          'RequestFulfilledEvent callback failed, still marking fulfilled'
+        );
+      }
+    } else {
+      logger.warn({ nodeId, requestId }, 'No callback source URL on record — marking fulfilled without notification');
+    }
+
+    await this.db
+      .updateTable('pcf_requests')
+      .set({
+        status: 'fulfilled',
+        resultCount: footprints.length,
+        fulfilledFootprintIds: JSON.stringify(footprintIds) as unknown as unknown[],
+        updatedAt: new Date(),
+      })
+      .where('id', '=', requestId)
+      .execute();
+
+    logger.info({ nodeId, requestId, footprintCount: footprints.length }, 'PCF request fulfilled');
+  }
+
+  async reject(
+    context: UserContext,
+    nodeId: number,
+    requestId: number
+  ): Promise<void> {
+    const node = await this.nodeService.get(context, nodeId);
+
+    const allowed =
+      context.policies.includes('manage-connections-all-nodes') ||
+      (context.policies.includes('manage-connections-own-nodes') &&
+        context.organizationId === node.organizationId);
+
+    if (!allowed) {
+      throw new ForbiddenError('You are not allowed to reject PCF requests for this node');
+    }
+
+    const request = await this.db
+      .selectFrom('pcf_requests')
+      .selectAll()
+      .where('id', '=', requestId)
+      .where('targetNodeId', '=', nodeId)
+      .where('status', '=', 'pending')
+      .executeTakeFirst();
+
+    if (!request) {
+      throw new NotFoundError('Pending incoming PCF request not found');
+    }
+
+    const callbackUrl = request.source
+      ? (request.source.endsWith('/3/events') ? request.source : `${request.source.replace(/\/+$/, '')}/3/events`)
+      : null;
+
+    if (callbackUrl) {
+      const authToken = await this.getCallbackToken(nodeId, request.fromNodeId ?? null);
+      const selfSource = `${this.directoryApiBaseUrl}/api/nodes/${nodeId}`;
+
+      const event = {
+        type: EventTypes.RequestRejected,
+        specversion: '1.0',
+        id: crypto.randomUUID(),
+        source: selfSource,
+        time: new Date().toISOString(),
+        data: { requestEventId: request.requestEventId, error: { code: 'AccessDenied', message: 'The request was rejected by the data owner.' } },
+      };
+
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      if (authToken) headers['Authorization'] = `Bearer ${authToken}`;
+
+      const response = await fetch(callbackUrl, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(event),
+      });
+
+      if (!response.ok) {
+        const body = await response.text().catch(() => '');
+        logger.warn({ nodeId, requestId, status: response.status, body }, 'RequestRejectedEvent callback failed, still marking rejected');
+      }
+    } else {
+      logger.warn({ nodeId, requestId }, 'No callback source URL on record — marking rejected without notification');
+    }
+
+    await this.db
+      .updateTable('pcf_requests')
+      .set({ status: 'rejected', updatedAt: new Date() })
+      .where('id', '=', requestId)
+      .execute();
+
+    logger.info({ nodeId, requestId }, 'PCF request rejected');
+  }
+
+  /**
+   * Get an auth token to send callbacks to the node that submitted the request.
+   * Finds the reverse connection (this node → from node) and authenticates.
+   */
+  private async getCallbackToken(nodeId: number, fromNodeId: number | null): Promise<string> {
+    try {
+      // Find outgoing accepted connection from this node to the requester
+      const connection = fromNodeId
+        ? await this.db
+            .selectFrom('connections')
+            .select(['clientId', 'clientSecret'])
+            .where('fromNodeId', '=', nodeId)
+            .where('targetNodeId', '=', fromNodeId)
+            .where('status', '=', 'accepted')
+            .executeTakeFirst()
+        : null;
+
+      if (!connection) {
+        logger.warn({ nodeId, fromNodeId }, 'No reverse connection found for callback auth — proceeding unauthenticated');
+        return '';
+      }
+
+      const clientSecret = this.decryptSecret(connection.clientSecret);
+      const authUrl = `${this.directoryApiBaseUrl}/api/nodes/${fromNodeId}/auth/token`;
+      const basicAuth = Buffer.from(`${connection.clientId}:${clientSecret}`).toString('base64');
+
+      const authResponse = await fetch(authUrl, {
+        method: 'POST',
+        headers: {
+          Authorization: `Basic ${basicAuth}`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: 'grant_type=client_credentials',
+      });
+
+      if (authResponse.ok) {
+        const tokenData = await authResponse.json() as { access_token: string };
+        return tokenData.access_token;
+      }
+
+      logger.warn({ nodeId, fromNodeId, status: authResponse.status }, 'Failed to obtain callback auth token');
+      return '';
+    } catch (err) {
+      logger.warn({ nodeId, fromNodeId, error: (err as Error).message }, 'Error obtaining callback auth token');
+      return '';
+    }
   }
 
   private decryptSecret(encrypted: string): string {

--- a/apps/api/src/services/pcf-request-service.ts
+++ b/apps/api/src/services/pcf-request-service.ts
@@ -359,6 +359,50 @@ export class PcfRequestService {
       .where('id', '=', requestId)
       .execute();
 
+    // When the requesting node is local (shares this database), write the PCFs
+    // directly into its product_footprints. This is required because the HTTP
+    // callback path (above) may fail if no reverse connection exists for auth.
+    if (request.fromNodeId !== null) {
+      const requesterNodeExists = await this.db
+        .selectFrom('nodes')
+        .select('id')
+        .where('id', '=', request.fromNodeId)
+        .executeTakeFirst();
+
+      if (requesterNodeExists) {
+        for (const pf of footprints) {
+          const pfData = pf as Record<string, unknown>;
+          if (!pfData?.id) continue;
+
+          const existing = await this.db
+            .selectFrom('product_footprints')
+            .select('id')
+            .where('nodeId', '=', request.fromNodeId)
+            .where(sql`data->>'id'`, '=', pfData.id as string)
+            .executeTakeFirst();
+
+          if (existing) {
+            await this.db
+              .updateTable('product_footprints')
+              .set({ data: pfData, updatedAt: new Date() })
+              .where('id', '=', existing.id)
+              .execute();
+          } else {
+            await this.db
+              .insertInto('product_footprints')
+              .values({
+                nodeId: request.fromNodeId,
+                data: pfData,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+              })
+              .execute();
+          }
+        }
+        logger.info({ nodeId, requestId, fromNodeId: request.fromNodeId, count: footprints.length }, 'PCFs written directly to requester node records (local node)');
+      }
+    }
+
     logger.info({ nodeId, requestId, footprintCount: footprints.length }, 'PCF request fulfilled');
   }
 

--- a/apps/api/src/services/pcf-request-service.ts
+++ b/apps/api/src/services/pcf-request-service.ts
@@ -374,30 +374,22 @@ export class PcfRequestService {
           const pfData = pf as Record<string, unknown>;
           if (!pfData?.id) continue;
 
-          const existing = await this.db
-            .selectFrom('product_footprints')
-            .select('id')
-            .where('nodeId', '=', request.fromNodeId)
-            .where(sql`data->>'id'`, '=', pfData.id as string)
-            .executeTakeFirst();
-
-          if (existing) {
-            await this.db
-              .updateTable('product_footprints')
-              .set({ data: pfData, updatedAt: new Date() })
-              .where('id', '=', existing.id)
-              .execute();
-          } else {
-            await this.db
-              .insertInto('product_footprints')
-              .values({
-                nodeId: request.fromNodeId,
+          await this.db
+            .insertInto('product_footprints')
+            .values({
+              id: pfData.id as string,
+              nodeId: request.fromNodeId,
+              data: pfData,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            })
+            .onConflict((oc) =>
+              oc.columns(['id', 'nodeId']).doUpdateSet({
                 data: pfData,
-                createdAt: new Date(),
                 updatedAt: new Date(),
               })
-              .execute();
-          }
+            )
+            .execute();
         }
         logger.info({ nodeId, requestId, fromNodeId: request.fromNodeId, count: footprints.length }, 'PCFs written directly to requester node records (local node)');
       }

--- a/apps/directory-portal/src/components/FulfillPcfRequestForm.tsx
+++ b/apps/directory-portal/src/components/FulfillPcfRequestForm.tsx
@@ -1,0 +1,225 @@
+import React, { useEffect, useState } from "react";
+import {
+  Badge,
+  Box,
+  Button,
+  Callout,
+  Checkbox,
+  Flex,
+  Spinner,
+  Text,
+} from "@radix-ui/themes";
+import {
+  ExclamationTriangleIcon,
+  InfoCircledIcon,
+} from "@radix-ui/react-icons";
+import { fetchWithAuth } from "../utils/auth-fetch";
+
+interface PcfRequest {
+  id: number;
+  fromNodeId: number | null;
+  fromNodeName?: string;
+  requestEventId: string;
+  filters: Record<string, unknown>;
+}
+
+interface Footprint {
+  id: string;
+  data: {
+    id?: string;
+    productNameCompany?: string;
+    companyName?: string;
+    status?: string;
+    productIds?: string[];
+  };
+}
+
+interface Props {
+  nodeId: number;
+  request: PcfRequest;
+  onCancel: () => void;
+  onFulfilled: () => void;
+}
+
+const FulfillPcfRequestForm: React.FC<Props> = ({
+  nodeId,
+  request,
+  onCancel,
+  onFulfilled,
+}) => {
+  const [footprints, setFootprints] = useState<Footprint[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const fromNodeLabel =
+    request.fromNodeName ??
+    (request.fromNodeId ? `Node #${request.fromNodeId}` : "External node");
+
+  const productIds = (request.filters.productId as string[] | undefined) ?? [];
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        setLoadError(null);
+        // Fetch footprints for this node (up to 100; user can filter further if needed)
+        const res = await fetchWithAuth(`/nodes/${nodeId}/footprints?page=1&pageSize=100`);
+        if (!res?.ok) throw new Error("Failed to load footprints");
+        const result = await res.json();
+        const rows: Footprint[] = (result.data ?? []).map((row: { id: string; data: Footprint["data"] }) => ({
+          id: row.id,
+          data: row.data ?? {},
+        }));
+        setFootprints(rows);
+      } catch (err) {
+        setLoadError(err instanceof Error ? err.message : "Failed to load footprints");
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [nodeId]);
+
+  const toggleSelected = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleSubmit = async () => {
+    if (selected.size === 0) {
+      setSubmitError("Select at least one PCF record to fulfill the request.");
+      return;
+    }
+    try {
+      setSubmitting(true);
+      setSubmitError(null);
+      const res = await fetchWithAuth(
+        `/nodes/${nodeId}/pcf-requests/${request.id}/fulfill`,
+        {
+          method: "POST",
+          body: JSON.stringify({ footprintIds: Array.from(selected) }),
+        }
+      );
+      if (!res?.ok) {
+        const body = await res?.json().catch(() => null);
+        throw new Error(body?.message ?? "Failed to fulfill request");
+      }
+      onFulfilled();
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : "An unexpected error occurred");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Flex direction="column" gap="4">
+      {/* Request context */}
+      <Callout.Root color="gray" variant="soft">
+        <Callout.Icon><InfoCircledIcon /></Callout.Icon>
+        <Callout.Text>
+          <strong>From:</strong> {fromNodeLabel}
+          {productIds.length > 0 && (
+            <>
+              {" · "}
+              <strong>Product IDs:</strong> {productIds.join(", ")}
+            </>
+          )}
+        </Callout.Text>
+      </Callout.Root>
+
+      {/* Footprint list */}
+      {loading && (
+        <Flex align="center" justify="center" py="6">
+          <Spinner size="3" />
+        </Flex>
+      )}
+
+      {loadError && (
+        <Callout.Root color="red">
+          <Callout.Icon><ExclamationTriangleIcon /></Callout.Icon>
+          <Callout.Text>{loadError}</Callout.Text>
+        </Callout.Root>
+      )}
+
+      {!loading && !loadError && footprints.length === 0 && (
+        <Callout.Root color="yellow">
+          <Callout.Icon><ExclamationTriangleIcon /></Callout.Icon>
+          <Callout.Text>
+            No PCF records found for this node. Use <strong>Create &amp; Fulfill</strong> to add one first.
+          </Callout.Text>
+        </Callout.Root>
+      )}
+
+      {!loading && footprints.length > 0 && (
+        <Box>
+          <Text size="2" color="gray" mb="2" as="p">
+            Select the PCF records to include in the response:
+          </Text>
+          <Flex direction="column" gap="2">
+            {footprints.map((fp) => {
+              const pcfId = fp.data.id ?? fp.id;
+              const name = fp.data.productNameCompany ?? pcfId;
+              const company = fp.data.companyName;
+              const status = fp.data.status;
+              return (
+                <Box
+                  key={fp.id}
+                  p="3"
+                  style={{
+                    border: "1px solid var(--gray-a5)",
+                    borderRadius: "var(--radius-2)",
+                    cursor: "pointer",
+                    background: selected.has(fp.id) ? "var(--accent-a2)" : undefined,
+                  }}
+                  onClick={() => toggleSelected(fp.id)}
+                >
+                  <Flex align="center" gap="3">
+                    <Checkbox checked={selected.has(fp.id)} onCheckedChange={() => toggleSelected(fp.id)} />
+                    <Box flexGrow="1">
+                      <Text size="2" weight="medium">{name}</Text>
+                      {company && <Text size="1" color="gray" as="p">{company}</Text>}
+                    </Box>
+                    {status && (
+                      <Badge color={status === "Active" ? "green" : "gray"} size="1">
+                        {status}
+                      </Badge>
+                    )}
+                  </Flex>
+                </Box>
+              );
+            })}
+          </Flex>
+        </Box>
+      )}
+
+      {submitError && (
+        <Callout.Root color="red">
+          <Callout.Icon><ExclamationTriangleIcon /></Callout.Icon>
+          <Callout.Text>{submitError}</Callout.Text>
+        </Callout.Root>
+      )}
+
+      <Flex gap="2" justify="end" mt="2">
+        <Button variant="soft" onClick={onCancel} disabled={submitting}>
+          Cancel
+        </Button>
+        <Button
+          onClick={handleSubmit}
+          disabled={submitting || loading || footprints.length === 0}
+          loading={submitting}
+        >
+          Fulfill Request
+        </Button>
+      </Flex>
+    </Flex>
+  );
+};
+
+export default FulfillPcfRequestForm;

--- a/apps/directory-portal/src/components/RequestPcfForm.tsx
+++ b/apps/directory-portal/src/components/RequestPcfForm.tsx
@@ -84,7 +84,10 @@ const RequestPcfForm: React.FC<RequestPcfFormProps> = ({
       );
       if (!res?.ok) throw new Error("Failed to fetch connections");
       const result = await res.json();
-      setConnections(result.data ?? []);
+      // Only show outgoing connections (where this node is the initiator) — those are
+      // the ones with valid credentials to call the target's PACT API.
+      const all: NodeConnection[] = result.data ?? [];
+      setConnections(all.filter((c) => c.fromNodeId === fromNodeId));
     } catch {
       setErrorMessage("Failed to load connections. Please try again.");
       setStatus("error");

--- a/apps/directory-portal/src/pages/NodeDashboardPage.tsx
+++ b/apps/directory-portal/src/pages/NodeDashboardPage.tsx
@@ -34,6 +34,7 @@ import { NodeConnection } from "../components/NodeConnectionsManager";
 import CreateNodeConnectionForm from "../components/CreateNodeConnectionForm";
 import RequestPcfForm from "../components/RequestPcfForm";
 import ImportFootprintsForm from "../components/ImportFootprintsForm";
+import FulfillPcfRequestForm from "../components/FulfillPcfRequestForm";
 import "./NodeDashboardPage.css";
 
 interface NodeData {
@@ -73,14 +74,19 @@ interface ConnectionCredentials {
 
 interface PcfRequest {
   id: number;
-  fromNodeId: number;
+  fromNodeId: number | null;
+  fromNodeName?: string;
   targetNodeId: number;
   targetNodeName?: string;
-  connectionId: number;
+  connectionId: number | null;
   requestEventId: string;
+  source: string | null;
   filters: Record<string, unknown>;
   status: "pending" | "fulfilled" | "rejected";
   resultCount: number | null;
+  fulfilledFootprintIds: unknown[] | null;
+  direction: "outgoing" | "incoming";
+  fulfillable?: boolean;
   createdAt: string;
   updatedAt: string;
 }
@@ -91,7 +97,8 @@ type PanelState =
   | { mode: "connections" }
   | { mode: "createConnection" }
   | { mode: "requestPcf" }
-  | { mode: "importPcf" };
+  | { mode: "importPcf" }
+  | { mode: "fulfillPcfRequest"; request: PcfRequest };
 
 const getLevelColor = (
   level: string
@@ -147,6 +154,7 @@ const NodeDashboardPage: React.FC = () => {
   const [pcfRequestsRefreshTrigger, setPcfRequestsRefreshTrigger] = useState(0);
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState("");
+  const [rejectingId, setRejectingId] = useState<number | null>(null);
 
   const closePanel = useCallback(() => setPanel({ mode: "closed" }), []);
   const handleSaved = useCallback(() => {
@@ -284,6 +292,19 @@ const NodeDashboardPage: React.FC = () => {
       // silently ignore
     }
   }, []);
+  const handleRejectPcfRequest = useCallback(async (request: PcfRequest) => {
+    if (!confirm(`Reject PCF request from ${request.fromNodeName ?? `Node #${request.fromNodeId}`}? A rejection event will be sent.`)) return;
+    setRejectingId(request.id);
+    try {
+      await fetchWithAuth(`/nodes/${nodeId}/pcf-requests/${request.id}/reject`, { method: "POST" });
+      setPcfRequestsRefreshTrigger((prev) => prev + 1);
+    } catch {
+      // silently ignore
+    } finally {
+      setRejectingId(null);
+    }
+  }, [nodeId]);
+
   const fetchPcfRequests = useCallback(async (params: {
     page: number;
     pageSize: number;
@@ -445,11 +466,24 @@ const NodeDashboardPage: React.FC = () => {
 
   const pcfRequestColumns: Column<PcfRequest>[] = [
     {
-      key: "targetNodeId",
-      header: "Target Node",
+      key: "direction",
+      header: "Direction",
       render: (row) => (
-        <Text size="2">{row.targetNodeName ?? `Node #${row.targetNodeId}`}</Text>
+        <Badge color={row.direction === "incoming" ? "jade" : "gray"} variant="soft" style={{ textTransform: "capitalize" }}>
+          {row.direction === "incoming" ? "Received" : "Sent"}
+        </Badge>
       ),
+    },
+    {
+      key: "node",
+      header: "Node",
+      render: (row) => {
+        if (row.direction === "incoming") {
+          const name = row.fromNodeName ?? (row.fromNodeId ? `Node #${row.fromNodeId}` : "External");
+          return <Text size="2">{name}</Text>;
+        }
+        return <Text size="2">{row.targetNodeName ?? `Node #${row.targetNodeId}`}</Text>;
+      },
     },
     {
       key: "status",
@@ -461,18 +495,57 @@ const NodeDashboardPage: React.FC = () => {
       ),
     },
     {
-      key: "resultCount",
-      header: "Results",
-      render: (row) => (
-        <Text size="2">
-          {row.status === "fulfilled" ? (row.resultCount ?? 0) : "—"}
-        </Text>
-      ),
+      key: "fulfillable",
+      header: "Fulfillable",
+      render: (row) => {
+        if (row.direction !== "incoming" || row.status !== "pending") return <Text size="2" color="gray">—</Text>;
+        return (
+          <Badge color={row.fulfillable ? "green" : "gray"} variant="soft">
+            {row.fulfillable ? "Yes" : "No"}
+          </Badge>
+        );
+      },
     },
     {
       key: "createdAt",
-      header: "Sent",
+      header: "Date",
       render: (row) => <Text size="2">{formatDate(row.createdAt)}</Text>,
+    },
+    {
+      key: "actions",
+      header: "",
+      extendedStyle: { textAlign: "right", whiteSpace: "nowrap" },
+      render: (row) => {
+        if (row.direction !== "incoming" || row.status !== "pending") return null;
+        return (
+          <Flex gap="2" justify="end">
+            <Button
+              size="1"
+              variant="soft"
+              color="green"
+              onClick={(e) => { e.stopPropagation(); setPanel({ mode: "fulfillPcfRequest", request: row }); }}
+            >
+              <CheckIcon /> Fulfill
+            </Button>
+            <Button
+              size="1"
+              variant="soft"
+              onClick={(e) => { e.stopPropagation(); navigate(`/nodes/${nodeId}/footprints/new`); }}
+            >
+              <PlusIcon /> Create &amp; Fulfill
+            </Button>
+            <Button
+              size="1"
+              variant="soft"
+              color="red"
+              disabled={rejectingId === row.id}
+              onClick={(e) => { e.stopPropagation(); handleRejectPcfRequest(row); }}
+            >
+              <Cross2Icon /> Reject
+            </Button>
+          </Flex>
+        );
+      },
     },
   ];
 
@@ -521,6 +594,7 @@ const NodeDashboardPage: React.FC = () => {
     panel.mode === "createConnection" ? "Create Connection" :
     panel.mode === "requestPcf" ? "Request PCF" :
     panel.mode === "importPcf" ? "Import PCFs" :
+    panel.mode === "fulfillPcfRequest" ? "Fulfill PCF Request" :
     "";
 
   const panelSubtitle = nodeData?.name;
@@ -670,8 +744,8 @@ const NodeDashboardPage: React.FC = () => {
               defaultPageSize={5}
               refreshTrigger={pcfRequestsRefreshTrigger}
               emptyState={{
-                title: "No PCF requests sent",
-                description: "PCF requests sent to connected nodes will appear here.",
+                title: "No PCF requests",
+                description: "Sent and received PCF requests will appear here.",
               }}
             />
           </section>
@@ -765,6 +839,18 @@ const NodeDashboardPage: React.FC = () => {
             nodeId={Number(nodeId)}
             onCancel={handlePanelClose}
             onImported={() => setRefreshTrigger((prev) => prev + 1)}
+          />
+        )}
+        {panel.mode === "fulfillPcfRequest" && nodeId && (
+          <FulfillPcfRequestForm
+            key={panel.request.id}
+            nodeId={Number(nodeId)}
+            request={panel.request}
+            onCancel={handlePanelClose}
+            onFulfilled={() => {
+              setPcfRequestsRefreshTrigger((prev) => prev + 1);
+              handlePanelClose();
+            }}
           />
         )}
       </SlideOverPanel>


### PR DESCRIPTION
## Outgoing requests:
<img width="1451" height="274" alt="Screenshot 2026-04-17 at 01 51 30" src="https://github.com/user-attachments/assets/0dcc3ff9-2a09-4b0a-bfa0-c528f05a4c51" />

## Incoming requests:
<img width="1423" height="258" alt="Screenshot 2026-04-17 at 01 51 47" src="https://github.com/user-attachments/assets/23a01adb-59cc-4635-ace6-04679f75e281" />

Accepting an incoming PCF also creates that PCF in the requestor Node's internal database.

Adds unit tests for corner cases and possible scenarios where issues might arise.