### PR TITLE
feat: simplify email service with htmlToText and centralized layout

### DIFF
--- a/apps/api/src/services/email-service.test.ts
+++ b/apps/api/src/services/email-service.test.ts
@@ -190,7 +190,7 @@ describe('EmailService', () => {
       await emailService.sendConnectionRequestEmail(mockParams);
 
       const message = mockRequest.mock.calls[0][0].Messages[0];
-      expect(message.HTMLPart).toContain('https://pact-directory-portal.onrender.com/manage-connections');
+      expect(message.HTMLPart).toContain(`${config.FRONTEND_URL}/manage-connections`);
     });
 
     it('should log success message after sending', async () => {
@@ -289,7 +289,7 @@ describe('EmailService', () => {
 
       const message = mockRequest.mock.calls[0][0].Messages[0];
       expect(message.To[0].Email).toBe(mockParams.to);
-      expect(message.Subject).toBe('PACT Directory feedback from Alice Brown');
+      expect(message.Subject).toBe(`PACT Network feedback from ${mockParams.senderName}`);
       expect(message.TextPart).toContain(mockParams.pagePath);
       expect(message.TextPart).toContain(mockParams.message);
       expect(message.HTMLPart).toContain(mockParams.senderEmail);

--- a/apps/api/src/services/email-service.test.ts
+++ b/apps/api/src/services/email-service.test.ts
@@ -1,7 +1,7 @@
-import { EmailService } from './email-service';
 import config from '@src/common/config';
 import logger from '@src/common/logger';
 import Mailjet from 'node-mailjet';
+import { EmailService, htmlToText } from './email-service';
 
 // Mock dependencies
 jest.mock('node-mailjet');
@@ -300,6 +300,71 @@ describe('EmailService', () => {
       await emailService.sendFeedbackEmail(mockParams);
 
       expect(logger.info).toHaveBeenCalledWith('Feedback email sent to pact-support@wbcsd.org');
+    });
+  });
+
+  describe('htmlToText', () => {
+    it('converts <h1> to # heading', () => {
+      expect(htmlToText('<h1>Hello World</h1>')).toBe('# Hello World');
+    });
+
+    it('converts <h2> and <h3> with the correct number of hashes', () => {
+      expect(htmlToText('<h2>Section</h2>')).toBe('## Section');
+      expect(htmlToText('<h3>Sub</h3>')).toBe('### Sub');
+    });
+
+    it('converts <h1> with inline style attribute', () => {
+      expect(htmlToText('<h1 style="color: red;">Styled</h1>')).toBe('# Styled');
+    });
+
+    it('converts <p> to text followed by a blank line', () => {
+      expect(htmlToText('<p>First</p><p>Second</p>')).toBe('First\n\nSecond');
+    });
+
+    it('trims surrounding whitespace from the result', () => {
+      expect(htmlToText('<p>Hello</p>')).toBe('Hello');
+    });
+
+    it('converts <a href> to "link text <url>"', () => {
+      expect(htmlToText('<a href="https://example.com">Click here</a>')).toBe('Click here <https://example.com>');
+    });
+
+    it('converts <a href> with no text to "<url>"', () => {
+      expect(htmlToText('<a href="https://example.com"></a>')).toBe('<https://example.com>');
+    });
+
+    it('converts <br> and <br/> to newlines', () => {
+      expect(htmlToText('line1<br/>line2')).toBe('line1\nline2');
+      expect(htmlToText('line1<br>line2')).toBe('line1\nline2');
+    });
+
+    it('strips unrecognised tags like <strong> and <div>', () => {
+      expect(htmlToText('<strong>bold</strong>')).toBe('bold');
+      expect(htmlToText('<div><p>Wrapped</p></div>')).toBe('Wrapped');
+    });
+
+    it('handles an anchor nested inside a paragraph', () => {
+      const result = htmlToText('<p>Visit <a href="https://example.com">our site</a>.</p>');
+      expect(result).toBe('Visit our site <https://example.com>.');
+    });
+
+    it('collapses three or more consecutive newlines to two', () => {
+      const result = htmlToText('<p>A</p><p></p><p>B</p>');
+      expect(result).not.toMatch(/\n{3,}/);
+    });
+
+    it('produces expected plain text from a typical email fragment', () => {
+      const html = [
+        '<h2>Welcome!</h2>',
+        '<p>Hi Jane,</p>',
+        '<div>Thank you for joining <strong>Test Company</strong>.</div>',
+        '<p>Please <a href="https://example.com/verify">verify your email</a>.</p>',
+      ].join('');
+      const result = htmlToText(html);
+      expect(result).toContain('## Welcome!');
+      expect(result).toContain('Hi Jane,');
+      expect(result).toContain('Thank you for joining Test Company.');
+      expect(result).toContain('verify your email <https://example.com/verify>');
     });
   });
 

--- a/apps/api/src/services/email-service.ts
+++ b/apps/api/src/services/email-service.ts
@@ -2,6 +2,47 @@ import config from '@src/common/config';
 import logger from '@src/common/logger';
 import Mailjet from 'node-mailjet';
 
+/**
+ * Convert a subset of HTML to plain text.
+ *
+ * Rules applied in order:
+ *   <hN>…</hN>         → repeated '#' followed by the heading text
+ *   <a href="…">…</a>  → link-text <url>
+ *   <p>…</p>           → paragraph text followed by a blank line
+ *   <br> / <br/>       → newline
+ *   all remaining tags → stripped
+ */
+export function htmlToText(html: string): string {
+  // Null-byte placeholders protect the angle brackets around URLs from
+  // the final "strip all remaining tags" step.
+  const OPEN = '\x00LT\x00';
+  const CLOSE = '\x00GT\x00';
+
+  return html
+    .replace(/<h([1-6])[^>]*>([\s\S]*?)<\/h\1>/gi, (_, level: string, inner: string) => {
+      const text = inner.replace(/<[^>]+>/g, '').trim();
+      return `${'#'.repeat(Number(level))} ${text}\n\n`;
+    })
+    .replace(/<a\s[^>]*href="([^"]*)"[^>]*>([\s\S]*?)<\/a>/gi, (_, url: string, inner: string) => {
+      const text = inner.replace(/<[^>]+>/g, '').trim();
+      return text ? `${text} ${OPEN}${url}${CLOSE}` : `${OPEN}${url}${CLOSE}`;
+    })
+    .replace(/<p[^>]*>([\s\S]*?)<\/p>/gi, (_, inner: string) => {
+      const text = inner.replace(/<[^>]+>/g, '').trim();
+      return `${text}\n\n`;
+    })
+    .replace(/<div[^>]*>([\s\S]*?)<\/div>/gi, (_, inner: string) => {
+      const text = inner.replace(/<[^>]+>/g, '').trim();
+      return `${text}\n\n`;
+    })
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<[^>]+>/g, '')
+    .replace(/\x00LT\x00/g, '<')
+    .replace(/\x00GT\x00/g, '>')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
 interface SendNotificationEmailParams {
   to: string;
   name: string;
@@ -25,6 +66,12 @@ interface SendFeedbackEmailParams {
   message: string;
 }
 
+/**
+ * EmailService handles sending various transactional emails using Mailjet. If the
+ * MAIL_API_KEY or MAIL_API_SECRET configuration values are missing, it will log the email
+ * content instead of sending, allowing the application to function without a 
+ * configured email provider in development environments.
+ */
 export class EmailService {
   private mailjet?: InstanceType<typeof Mailjet.Client>;
   private mockMode: boolean;
@@ -44,11 +91,23 @@ export class EmailService {
     to: string;
     subject: string;
     html: string;
-    text: string;
+    text?: string;
   }): Promise<void> {
+    const wrappedHtml = `
+      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+        ${params.html}
+        <p>
+          PACT Network<br/>
+          <a href="${config.FRONTEND_URL}">${config.FRONTEND_URL}</a><br/>
+          Part of the World Business Council for Sustainable Development (<a href="https://www.wbcsd.org">WBCSD</a>)
+        </p>
+      </div>
+    `;
+    const text = params.text ?? htmlToText(wrappedHtml);
+
     if (this.mockMode) {
       logger.debug('--- MAILJET MOCK SEND ---');
-      logger.debug(params);
+      logger.debug({ ...params, text, html: wrappedHtml });
       logger.debug('--- END MAILJET MOCK SEND ---');
       return;
     }
@@ -63,8 +122,8 @@ export class EmailService {
             },
             To: [{ Email: params.to }],
             Subject: params.subject,
-            TextPart: params.text,
-            HTMLPart: params.html,
+            TextPart: text,
+            HTMLPart: wrappedHtml,
           },
         ],
       });
@@ -83,10 +142,9 @@ export class EmailService {
     const { to, name, organizationName, setupUrl } = params;
     
     const htmlContent = `
-      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
         <h2>Welcome to the PACT Network!</h2>
         <p>Hi ${name},</p>
-        <p>An administrator from ${organizationName} has created an account for you. To get started, please set your password by clicking the link below:</p>
+        <p>An administrator from ${organizationName} has created an account on the PACT Network for you. To get started, please set your password by clicking the link below:</p>
         <div style="text-align: center; margin: 30px 0;">
           <a href="${setupUrl}"
             style="background-color: #007bff; color: white; padding: 12px 24px; text-decoration: none; border-radius: 4px; display: inline-block;">
@@ -95,30 +153,12 @@ export class EmailService {
         </div>
         <p>This link will expire in 72 hours.</p>
         <p>If you didn't expect this email or believe you received it by mistake, please contact your administrator.</p>
-        <p>Best regards,<br>The PACT Team</p>
-      </div>
     `;
 
-    const textContent = [
-      `Hello ${name},`,
-      '',
-      `An administrator from ${organizationName} has created an account for you. To get started, please set your password by clicking the link below:`,
-      '',
-      setupUrl,
-      '',
-      'This link will expire in 72 hours.',
-      '',
-      "If you didn't expect this email or believe you received it by mistake, please contact your administrator.",
-      '',
-      'Best regards,',
-      'The PACT Team',
-    ].join('\n');
-    
     await this.sendEmail({
       to,
       subject: `Set your password for ${organizationName}`,
       html: htmlContent,
-      text: textContent,
     });
     logger.info(`Password setup email sent to ${to}`);
   }
@@ -132,7 +172,6 @@ export class EmailService {
     const { to, name, organizationName, verificationUrl } = params;
 
     const htmlContent = `
-      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
         <h2>Welcome to the PACT Network!</h2>
         <p>Hi ${name},</p>
         <p>Thank you for registering with us. To complete your registration and activate your account, please verify your email address by clicking the link below:</p>
@@ -144,30 +183,12 @@ export class EmailService {
         </div>
         <p>This link will expire in 24 hours.</p>
         <p>If you didn't create this account, you can safely ignore this email.</p>
-        <p>Best regards,<br>The PACT Team</p>
-      </div>
     `;
-
-    const textContent = [
-      `Hello ${name},`,
-      '',
-      'Thank you for registering with us. To complete your registration and activate your account, please verify your email address by clicking the link below:',
-      '',
-      verificationUrl,
-      '',
-      'This link will expire in 24 hours.',
-      '',
-      "If you didn't create this account, you can safely ignore this email.",
-      '',
-      'Best regards,',
-      'The PACT Team',
-    ].join('\n');
 
     await this.sendEmail({
       to,
       subject: `Please verify your email address for ${organizationName}`,
       html: htmlContent,
-      text: textContent,
     });
     logger.info(`Email verification sent to ${to}`);
   }
@@ -177,11 +198,16 @@ export class EmailService {
     name,
     organizationName: companyName,
   }: SendNotificationEmailParams) {
+    const htmlContent = `
+        <p>Hello ${name},</p>
+        <p>${companyName} has requested to connect with your organization on the PACT Network.
+           Please log in to your account to accept or reject the request.</p>
+        <p>You can manage your connections from ${config.FRONTEND_URL}/manage-connections</p>
+    `;
     await this.sendEmail({
       to,
       subject: 'Connection Request from PACT Network',
-      text: `Hello ${name},\n\n${companyName} has requested to connect with your organization on the PACT Network. Please log in to your account to accept or reject the request.\n\nBest regards,\nThe PACT Network Team`,
-      html: `<p>Hello ${name},</p><p>${companyName} has requested to connect with your organization on the PACT Network. Please log in to your account to accept or reject the request.</p><p>You can manage your connections from https://pact-directory-portal.onrender.com/manage-connections</p><p>Best regards,<br>The PACT Network</p>`,
+      html: htmlContent,
     });
     logger.info(`Email sent to ${name}`);
   }
@@ -191,22 +217,7 @@ export class EmailService {
     name,
     resetUrl,
   }: SendPasswordResetEmailParams): Promise<void> {
-    const textContent = [
-      `Hello ${name},`,
-      '',
-      'We received a request to reset your password for your PACT Network account.',
-      '',
-      'Click the link below to reset your password (expires in 15 minutes):',
-      resetUrl,
-      '',
-      "If you didn't request this reset, please ignore this email.",
-      '',
-      'Best regards,',
-      'The PACT Network Team',
-    ].join('\n');
-
     const htmlContent = `
-      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
         <h2 style="color: #0A0552;">Password Reset Request</h2>
         <p>Hello ${name},</p>
         <p>We received a request to reset your password for your PACT Network account.</p>
@@ -221,17 +232,14 @@ export class EmailService {
         <p>Or copy and paste this link into your browser:</p>
         <p style="word-break: break-all; color: #666;">${resetUrl}</p>
         <p style="color: #666; font-size: 14px; margin-top: 30px;">
-          If you didn't request this reset, please ignore this email. 
+          If you didn't request this reset, please ignore this email.
           Your password will not be changed.
         </p>
-        <p>Best regards,<br>The PACT Network Team</p>
-      </div>
     `;
 
     await this.sendEmail({
       to,
       subject: 'Password Reset Request - PACT Network',
-      text: textContent,
       html: htmlContent,
     });
     logger.info(`Password reset email sent to ${to}`);
@@ -247,39 +255,22 @@ export class EmailService {
     pageTitle,
     message,
   }: SendFeedbackEmailParams): Promise<void> {
-    const details = [
-      `Sender: ${senderName}`,
-      `Email: ${senderEmail}`,
-      `Organization: ${organizationName}`,
-      `Role: ${role}`,
-      `Page: ${pagePath}`,
-      ...(pageTitle ? [`Page title: ${pageTitle}`] : []),
-      '',
-      'Feedback message:',
-      message,
-    ];
-
-    const textContent = details.join('\n');
-
     const htmlContent = `
-      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
-        <h2 style="color: #0A0552;">PACT Directory Feedback</h2>
-        <p><strong>Sender:</strong> ${senderName}</p>
-        <p><strong>Email:</strong> ${senderEmail}</p>
-        <p><strong>Organization:</strong> ${organizationName}</p>
-        <p><strong>Role:</strong> ${role}</p>
-        <p><strong>Page:</strong> ${pagePath}</p>
-        ${pageTitle ? `<p><strong>Page title:</strong> ${pageTitle}</p>` : ''}
-        <hr style="border: none; border-top: 1px solid #ddd; margin: 24px 0;" />
-        <p><strong>Feedback message</strong></p>
-        <p style="white-space: pre-wrap;">${message}</p>
-      </div>
+        <h2>PACT Network Feedback</h2>
+        <p>Sender: ${senderName}</p>
+        <p>Email: ${senderEmail}</p>
+        <p>Organization: ${organizationName}</p>
+        <p>Role: ${role}</p>
+        <p>Page: ${pagePath}</p>
+        ${pageTitle ? `<p>Page title: ${pageTitle}</p>` : ''}
+        <hr />
+        <p>Feedback message</p>
+        <p>${message}</p>
     `;
 
     await this.sendEmail({
       to,
-      subject: `PACT Directory feedback from ${senderName}`,
-      text: textContent,
+      subject: `PACT Network feedback from ${senderName}`,
       html: htmlContent,
     });
     logger.info(`Feedback email sent to ${to}`);


### PR DESCRIPTION
## Summary

Refactors the `EmailService` to eliminate duplicated HTML structure and manually maintained plain-text versions across every send method.

## Changes

### `htmlToText` utility function
- New exported function that converts a subset of HTML to plain text following these rules:
  - `<hN>` → `# … ######` heading prefix
  - `<a href="url">text</a>` → `text <url>`
  - `<p>` → paragraph ending with a blank line
  - `<br>` → newline
  - All remaining tags stripped
- Uses null-byte placeholders to protect `<url>` angle brackets from the final tag-stripping pass.

### `sendEmail` (private)
- Now accepts `text` as an **optional** parameter (callers may override when needed).
- Automatically wraps the `html` fragment in the standard styled `<div>` container and appends the PACT Network footer before sending.
- Derives `TextPart` from `htmlToText(wrappedHtml)` when no `text` override is provided.

### All `send*` methods
- `htmlContent` now contains only the message body — no outer wrapper div, no footer.
- Manual `textContent` template literals / array joins removed from every method.
- Each call to `sendEmail` passes only `html:` (no `text:` argument).

## Tests

- Added 12 unit tests for `htmlToText` covering: heading levels, style attributes, paragraphs, anchors, empty anchors, `<br>` variants, tag stripping, nested anchors, newline collapsing, and a realistic email fragment.
- All 40 tests in `email-service.test.ts` pass.