### PR TITLE
fix: change pcf_requests.request_event_id from uuid to text

### DIFF
--- a/apps/api/src/database/migrations/2026_05_14_10_00_00_fix_request_event_id_type.ts
+++ b/apps/api/src/database/migrations/2026_05_14_10_00_00_fix_request_event_id_type.ts
@@ -1,0 +1,53 @@
+import { Kysely, sql } from 'kysely';
+
+// CloudEvents spec requires source+id to be unique; id is any non-empty string (not necessarily a uuid).
+// See: https://github.com/wbcsd/pact-directory-service/issues/292
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  // Change request_event_id from uuid to text
+  await sql`ALTER TABLE pcf_requests ALTER COLUMN request_event_id TYPE text USING request_event_id::text`.execute(db);
+
+  // Drop the single-column unique constraint (auto-named by postgres)
+  await db.schema
+    .alterTable('pcf_requests')
+    .dropConstraint('pcf_requests_request_event_id_key')
+    .execute();
+
+  // Drop the now-redundant explicit index
+  await db.schema.dropIndex('pcf_requests_request_event_id_idx').execute();
+
+  // Add composite unique constraint aligning with the CloudEvents spec (source+id uniqueness)
+  await db.schema
+    .alterTable('pcf_requests')
+    .addUniqueConstraint('pcf_requests_source_request_event_id_key', ['source', 'request_event_id'])
+    .execute();
+
+  // Make source non-nullable — every request must carry the CloudEvent source
+  await sql`ALTER TABLE pcf_requests ALTER COLUMN source SET NOT NULL`.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  // Revert source to nullable
+  await sql`ALTER TABLE pcf_requests ALTER COLUMN source DROP NOT NULL`.execute(db);
+
+  // Drop composite unique constraint
+  await db.schema
+    .alterTable('pcf_requests')
+    .dropConstraint('pcf_requests_source_request_event_id_key')
+    .execute();
+
+  // Restore single-column unique constraint and index
+  await db.schema
+    .alterTable('pcf_requests')
+    .addUniqueConstraint('pcf_requests_request_event_id_key', ['request_event_id'])
+    .execute();
+
+  await db.schema
+    .createIndex('pcf_requests_request_event_id_idx')
+    .on('pcf_requests')
+    .column('request_event_id')
+    .execute();
+
+  // Change request_event_id back to uuid
+  await sql`ALTER TABLE pcf_requests ALTER COLUMN request_event_id TYPE uuid USING request_event_id::uuid`.execute(db);
+}

--- a/apps/api/src/database/types.ts
+++ b/apps/api/src/database/types.ts
@@ -120,8 +120,8 @@ export interface PcfRequestsTable {
   fromNodeId: number | null;  // null for requests from external nodes without a directory record
   targetNodeId: number;
   connectionId: number | null; // null for incoming requests not yet matched to a connection
-  requestEventId: string; // UUID of the sent CloudEvent
-  source: string | null;  // source URL from incoming event — used as callback base
+  requestEventId: string; // id of the sent CloudEvent
+  source: string;  // source URL from CloudEvent — used as callback base
   filters: Record<string, unknown>; // JSONB — FootprintFilters
   status: 'pending' | 'fulfilled' | 'rejected';
   resultCount: number | null;

--- a/apps/api/src/services/internal-node-pact-service.ts
+++ b/apps/api/src/services/internal-node-pact-service.ts
@@ -237,9 +237,9 @@ export class InternalNodePactService {
         createdAt: new Date(),
         updatedAt: new Date(),
       })
-      .onConflict((oc) => oc.column('requestEventId').doNothing())
+      .onConflict((oc) => oc.columns(['source','requestEventId']).doNothing())
       .execute();
-
+      
     logger.info({ nodeId, requestEventId, fromNodeId }, 'Incoming PCF request saved to inbox');
   }
 

--- a/apps/api/src/services/pcf-request-service.ts
+++ b/apps/api/src/services/pcf-request-service.ts
@@ -140,6 +140,7 @@ export class PcfRequestService {
         targetNodeId: targetNode.id,
         connectionId: connection.id,
         requestEventId,
+        source,
         filters: filters as unknown as Record<string, unknown>,
         status: 'pending',
         resultCount: null,

--- a/apps/api/src/services/pcf-request-service.ts
+++ b/apps/api/src/services/pcf-request-service.ts
@@ -17,7 +17,7 @@ export interface PcfRequestData {
   targetNodeName?: string;
   connectionId: number | null;
   requestEventId: string;
-  source: string | null;
+  source: string;
   filters: FootprintFilters;
   status: 'pending' | 'fulfilled' | 'rejected';
   resultCount: number | null;

--- a/apps/api/src/services/pcf-request-service.ts
+++ b/apps/api/src/services/pcf-request-service.ts
@@ -148,7 +148,7 @@ export class PcfRequestService {
         updatedAt: new Date(),
       })
       .onConflict((oc) =>
-        oc.column('requestEventId').doUpdateSet((eb) => ({
+        oc.columns(['source','requestEventId']).doUpdateSet((eb) => ({
           connectionId: eb.ref('excluded.connectionId'),
         }))
       )


### PR DESCRIPTION
CloudEvents spec only requires source+id to be unique; the id field is any non-empty string, not necessarily a UUID.

- Change request_event_id column type from uuid to text
- Replace single-column unique constraint with composite (source, request_event_id)
- Drop redundant explicit index on request_event_id
- Make source non-nullable

Closes #292