### PR TITLE
Fixes an issue where empty dates (allowed) would cause a formatting error

### DIFF
--- a/apps/api/src/services/internal-node-pact-service.test.ts
+++ b/apps/api/src/services/internal-node-pact-service.test.ts
@@ -300,6 +300,36 @@ describe('InternalNodePactService', () => {
       expect(result.data).toHaveLength(1);
     });
 
+    // Conformance test cases 24/25/26: footprints with empty-string date fields must not
+    // cause a PostgreSQL "invalid input syntax for type timestamp with time zone: """
+    // error. NULLIF wraps ensure "" becomes NULL before the ::timestamptz cast.
+    it('should not throw when date fields are empty strings — validOn (TC#24)', async () => {
+      dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce({ total: 0 });
+      dbMocks.executors.execute.mockResolvedValueOnce([]);
+
+      await expect(
+        service.getFootprints(nodeId, { validOn: '2024-06-01T00:00:00Z' })
+      ).resolves.not.toThrow();
+    });
+
+    it('should not throw when date fields are empty strings — validAfter (TC#25)', async () => {
+      dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce({ total: 0 });
+      dbMocks.executors.execute.mockResolvedValueOnce([]);
+
+      await expect(
+        service.getFootprints(nodeId, { validAfter: '2023-01-14T00:00:00Z' })
+      ).resolves.not.toThrow();
+    });
+
+    it('should not throw when date fields are empty strings — validBefore (TC#26)', async () => {
+      dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce({ total: 0 });
+      dbMocks.executors.execute.mockResolvedValueOnce([]);
+
+      await expect(
+        service.getFootprints(nodeId, { validBefore: '2026-01-01T00:00:00Z' })
+      ).resolves.not.toThrow();
+    });
+
     it('should handle companyId filter — matches laptop with urn:uuid:12345678-1234-1234-1234-123456789012', async () => {
       dbMocks.executors.executeTakeFirstOrThrow.mockResolvedValueOnce({ total: 1 });
       dbMocks.executors.execute.mockResolvedValueOnce([mockFootprintRow]);

--- a/apps/api/src/services/internal-node-pact-service.ts
+++ b/apps/api/src/services/internal-node-pact-service.ts
@@ -332,13 +332,13 @@ export class InternalNodePactService {
     if (filters.validOn) {
       qb = qb.where(
         sql`COALESCE(
-          (data->>'validityPeriodStart')::timestamptz,
-          (data#>>'{pcf,referencePeriodEnd}')::timestamptz
+          NULLIF(data->>'validityPeriodStart', '')::timestamptz,
+          NULLIF(data#>>'{pcf,referencePeriodEnd}', '')::timestamptz
         ) <= ${filters.validOn}::timestamptz`
       ).where(
         sql`COALESCE(
-          (data->>'validityPeriodEnd')::timestamptz,
-          (data#>>'{pcf,referencePeriodEnd}')::timestamptz + interval '3 years'
+          NULLIF(data->>'validityPeriodEnd', '')::timestamptz,
+          NULLIF(data#>>'{pcf,referencePeriodEnd}', '')::timestamptz + interval '3 years'
         ) >= ${filters.validOn}::timestamptz`
       );
     }
@@ -347,8 +347,8 @@ export class InternalNodePactService {
     if (filters.validAfter) {
       qb = qb.where(
         sql`COALESCE(
-          (data->>'validityPeriodStart')::timestamptz,
-          (data#>>'{pcf,referencePeriodEnd}')::timestamptz
+          NULLIF(data->>'validityPeriodStart', '')::timestamptz,
+          NULLIF(data#>>'{pcf,referencePeriodEnd}', '')::timestamptz
         ) > ${filters.validAfter}::timestamptz`
       );
     }
@@ -357,8 +357,8 @@ export class InternalNodePactService {
     if (filters.validBefore) {
       qb = qb.where(
         sql`COALESCE(
-          (data->>'validityPeriodEnd')::timestamptz,
-          (data#>>'{pcf,referencePeriodEnd}')::timestamptz + interval '3 years'
+          NULLIF(data->>'validityPeriodEnd', '')::timestamptz,
+          NULLIF(data#>>'{pcf,referencePeriodEnd}', '')::timestamptz + interval '3 years'
         ) < ${filters.validBefore}::timestamptz`
       );
     }


### PR DESCRIPTION
Allowed empty strings for dates cause a filtering issue in the conformance test against internal nodes

<img width="800" height="139" alt="image" src="https://github.com/user-attachments/assets/1b453969-ade8-4ca5-a266-f48e4db00d4a" />
