### PR TITLE
Add a sticky reminder for root users and enable text confirmation for node deletion

### DIFF
--- a/apps/directory-portal/e2e/nodes.spec.ts
+++ b/apps/directory-portal/e2e/nodes.spec.ts
@@ -1,4 +1,6 @@
 import { test, expect } from "./fixtures";
+import { mockProfileData } from "./mocks/data/auth";
+import { mockNodeDetail } from "./mocks/data/nodes";
 
 test.describe("Nodes", () => {
   // ---------------------------------------------------------------------------
@@ -139,20 +141,166 @@ test.describe("Nodes", () => {
     await expect(page.getByRole("menuitem", { name: /edit node/i })).toBeVisible();
   });
 
-  test("delete node shows confirmation before deleting", async ({
+  test("delete node opens a confirmation dialog", async ({
     authenticatedPage: page,
   }) => {
     await page.goto("/nodes/100");
 
-    // Open dropdown menu via aria-haspopup button
     await page.locator('[aria-haspopup="menu"]').click();
     await page.getByRole("menuitem", { name: /delete node/i }).click();
 
-    // Expect a native confirm dialog — dismiss so node is NOT deleted
-    page.once("dialog", (dialog) => dialog.dismiss());
+    // Radix Dialog should open — not a native browser confirm
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await expect(page.getByRole("dialog").getByRole("heading", { name: /delete node/i })).toBeVisible();
+  });
 
-    // After dismissing the confirmation, we should still be on the same page
+  test("delete node — cancel keeps user on the page", async ({
+    authenticatedPage: page,
+  }) => {
+    await page.goto("/nodes/100");
+
+    await page.locator('[aria-haspopup="menu"]').click();
+    await page.getByRole("menuitem", { name: /delete node/i }).click();
+
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await page.getByRole("button", { name: /cancel/i }).click();
+
     await expect(page).toHaveURL(/\/nodes\/100/);
+  });
+
+  test("delete node — confirm button disabled until node name is typed", async ({
+    authenticatedPage: page,
+  }) => {
+    await page.goto("/nodes/100");
+
+    await page.locator('[aria-haspopup="menu"]').click();
+    await page.getByRole("menuitem", { name: /delete node/i }).click();
+
+    await expect(page.getByRole("dialog")).toBeVisible();
+
+    // Delete button should be disabled when the input is empty
+    const deleteButton = page.getByRole("dialog").getByRole("button", { name: /delete node/i });
+    await expect(deleteButton).toBeDisabled();
+
+    // Wrong name — still disabled
+    await page.getByRole("dialog").getByRole("textbox").fill("wrong name");
+    await expect(deleteButton).toBeDisabled();
+
+    // Correct name — now enabled
+    await page.getByRole("dialog").getByRole("textbox").fill("Test Node Alpha");
+    await expect(deleteButton).toBeEnabled();
+  });
+
+  test("delete node — completes after typing correct name", async ({
+    authenticatedPage: page,
+  }) => {
+    await page.goto("/nodes/100");
+
+    await page.locator('[aria-haspopup="menu"]').click();
+    await page.getByRole("menuitem", { name: /delete node/i }).click();
+
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await page.getByRole("dialog").getByRole("textbox").fill("Test Node Alpha");
+    await page.getByRole("dialog").getByRole("button", { name: /delete node/i }).click();
+
+    // After deletion the app navigates back to the nodes list
+    await expect(page).toHaveURL(/\/nodes$/);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Root user — sticky banner
+  // ---------------------------------------------------------------------------
+
+  test("root user sees the sticky root access banner", async ({
+    authenticatedPage: page,
+    setupMocks,
+  }) => {
+    await setupMocks({ getMe: { ...mockProfileData, role: "root" } });
+    await page.goto("/nodes");
+
+    await expect(page.getByText(/root access active/i)).toBeVisible();
+  });
+
+  test("non-root user does not see the root access banner", async ({
+    authenticatedPage: page,
+  }) => {
+    await page.goto("/nodes");
+
+    await expect(page.getByText(/root access active/i)).not.toBeVisible();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Root cross-org deletion — second confirmation dialog
+  // ---------------------------------------------------------------------------
+
+  test("root deleting a cross-org node shows a second warning dialog", async ({
+    authenticatedPage: page,
+    setupMocks,
+  }) => {
+    // Root user in org 10 viewing a node belonging to a different org
+    await setupMocks({
+      getMe: { ...mockProfileData, role: "root" },
+      getNode: { ...mockNodeDetail, organizationId: 99, organizationName: "Other Organisation" },
+    });
+    await page.goto("/nodes/100");
+
+    await page.locator('[aria-haspopup="menu"]').click();
+    await page.getByRole("menuitem", { name: /delete node/i }).click();
+
+    // Step 1 — type the node name to pass the first dialog
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await page.getByRole("dialog").getByRole("textbox").fill("Test Node Alpha");
+    await page.getByRole("dialog").getByRole("button", { name: /delete node/i }).click();
+
+    // Step 2 — cross-org warning dialog should appear
+    const crossOrgDialog = page.getByRole("dialog");
+    await expect(crossOrgDialog.getByRole("heading", { name: /delete node from another organization/i })).toBeVisible();
+    await expect(crossOrgDialog.getByText(/Other Organisation/i)).toBeVisible();
+  });
+
+  test("root can cancel the cross-org warning dialog", async ({
+    authenticatedPage: page,
+    setupMocks,
+  }) => {
+    await setupMocks({
+      getMe: { ...mockProfileData, role: "root" },
+      getNode: { ...mockNodeDetail, organizationId: 99, organizationName: "Other Organisation" },
+    });
+    await page.goto("/nodes/100");
+
+    await page.locator('[aria-haspopup="menu"]').click();
+    await page.getByRole("menuitem", { name: /delete node/i }).click();
+
+    await page.getByRole("dialog").getByRole("textbox").fill("Test Node Alpha");
+    await page.getByRole("dialog").getByRole("button", { name: /delete node/i }).click();
+
+    // Cancel on the second dialog — should stay on the node page
+    await expect(page.getByText(/delete node from another organization/i)).toBeVisible();
+    await page.getByRole("button", { name: /cancel/i }).click();
+    await expect(page).toHaveURL(/\/nodes\/100/);
+  });
+
+  test("root can confirm cross-org deletion via second dialog", async ({
+    authenticatedPage: page,
+    setupMocks,
+  }) => {
+    await setupMocks({
+      getMe: { ...mockProfileData, role: "root" },
+      getNode: { ...mockNodeDetail, organizationId: 99, organizationName: "Other Organisation" },
+    });
+    await page.goto("/nodes/100");
+
+    await page.locator('[aria-haspopup="menu"]').click();
+    await page.getByRole("menuitem", { name: /delete node/i }).click();
+
+    await page.getByRole("dialog").getByRole("textbox").fill("Test Node Alpha");
+    await page.getByRole("dialog").getByRole("button", { name: /delete node/i }).click();
+
+    await expect(page.getByText(/delete node from another organization/i)).toBeVisible();
+    await page.getByRole("button", { name: /confirm deletion/i }).click();
+
+    // After deletion the app navigates back to the nodes list
+    await expect(page).toHaveURL(/\/nodes$/);
   });
 
   // ---------------------------------------------------------------------------

--- a/apps/directory-portal/src/layouts/FunctionalPageLayout.tsx
+++ b/apps/directory-portal/src/layouts/FunctionalPageLayout.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from "react";
-import { Flex, IconButton } from "@radix-ui/themes";
-import { HamburgerMenuIcon, Cross2Icon } from "@radix-ui/react-icons";
+import { Callout, Flex, IconButton, Text } from "@radix-ui/themes";
+import { HamburgerMenuIcon, Cross2Icon, ExclamationTriangleIcon } from "@radix-ui/react-icons";
 import SideNav from "../components/SideNav";
 import LoadingSpinner from "../components/LoadingSpinner";
 import SignUp from "../components/SignUp";
 import FeedbackWidget from "../components/FeedbackWidget";
+import { useAuth } from "../contexts/AuthContext";
 import pactLogo from "../assets/pact-logo.svg";
 import pactLogoDark from "../assets/pact-logo-dark.svg";
 
@@ -20,6 +21,8 @@ const FunctionalPageLayout: React.FC<FunctionalPageLayoutProps> = ({
   loadingMessage = "Loading...",
 }) => {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const { profileData } = useAuth();
+  const isRoot = profileData?.role === "root";
 
   return (
     <div className="layout">
@@ -47,6 +50,18 @@ const FunctionalPageLayout: React.FC<FunctionalPageLayoutProps> = ({
           <SignUp />
         </div>
       </header>
+
+      {isRoot && (
+        <Callout.Root color="amber" variant="surface" style={{ borderRadius: 0, position: "sticky", top: 0, zIndex: 100 }}>
+          <Callout.Icon>
+            <ExclamationTriangleIcon />
+          </Callout.Icon>
+          <Callout.Text>
+            <Text weight="bold">Root access active.</Text>{" "}
+            You are logged in as a root user and can view and modify data across all organizations.
+          </Callout.Text>
+        </Callout.Root>
+      )}
 
       <div className="container">
         {mobileMenuOpen && (

--- a/apps/directory-portal/src/pages/NodeDashboardPage.tsx
+++ b/apps/directory-portal/src/pages/NodeDashboardPage.tsx
@@ -9,9 +9,11 @@ import {
   IconButton,
   Separator,
   Text,
+  TextField,
   Box,
   Flex
 } from "@radix-ui/themes";
+import { useAuth } from "../contexts/AuthContext";
 import {
   ArrowLeftIcon,
   CheckIcon,
@@ -154,6 +156,11 @@ const NodeDashboardPage: React.FC = () => {
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState("");
   const [rejectingId, setRejectingId] = useState<number | null>(null);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [deleteNameInput, setDeleteNameInput] = useState("");
+  const [crossOrgDialogOpen, setCrossOrgDialogOpen] = useState(false);
+
+  const { profileData } = useAuth();
 
   const copyToClipboard = useCallback(async (value: string) => {
     try {
@@ -197,8 +204,26 @@ const NodeDashboardPage: React.FC = () => {
     setConnectionsRefreshTrigger(prev => prev + 1);
   }, [closePanel]);
 
-  const handleDelete = async () => {
-    if (!window.confirm(`Are you sure you want to delete "${nodeData?.name}"? This action cannot be undone.`)) return;
+  const handleDelete = () => {
+    setDeleteNameInput("");
+    setDeleteError("");
+    setDeleteDialogOpen(true);
+  };
+
+  const handleConfirmDeleteName = () => {
+    const isRoot = profileData?.role === "root";
+    const isCrossOrg = nodeData?.organizationId !== profileData?.organizationId;
+    if (isRoot && isCrossOrg) {
+      setDeleteDialogOpen(false);
+      setCrossOrgDialogOpen(true);
+    } else {
+      performDelete();
+    }
+  };
+
+  const performDelete = async () => {
+    setDeleteDialogOpen(false);
+    setCrossOrgDialogOpen(false);
     try {
       setDeleting(true);
       const response = await fetchWithAuth(`/nodes/${nodeId}`, { method: "DELETE" });
@@ -955,6 +980,58 @@ const NodeDashboardPage: React.FC = () => {
           />
         )}
       </SlideOverPanel>
+
+      {/* Delete node — step 1: confirm by typing the node name */}
+      <Dialog.Root open={deleteDialogOpen} onOpenChange={(open) => { if (!open) setDeleteDialogOpen(false); }}>
+        <Dialog.Content maxWidth="460px">
+          <Dialog.Title>Delete node</Dialog.Title>
+          <Dialog.Description size="2" color="gray" mb="4">
+            This action <Text weight="bold">cannot be undone</Text>. Type the node name{" "}
+            <Text weight="bold">{nodeData?.name}</Text> to confirm deletion.
+          </Dialog.Description>
+          <TextField.Root
+            placeholder={nodeData?.name ?? ""}
+            value={deleteNameInput}
+            onChange={(e) => setDeleteNameInput(e.target.value)}
+            autoFocus
+          />
+          <Flex gap="3" mt="4" justify="end">
+            <Dialog.Close>
+              <Button variant="soft" color="gray">Cancel</Button>
+            </Dialog.Close>
+            <Button
+              color="red"
+              disabled={deleteNameInput !== nodeData?.name}
+              onClick={handleConfirmDeleteName}
+            >
+              <TrashIcon /> Delete node
+            </Button>
+          </Flex>
+        </Dialog.Content>
+      </Dialog.Root>
+
+      {/* Delete node — step 2 (root only): cross-org warning */}
+      <Dialog.Root open={crossOrgDialogOpen} onOpenChange={(open) => { if (!open) setCrossOrgDialogOpen(false); }}>
+        <Dialog.Content maxWidth="460px">
+          <Dialog.Title>Delete node from another organization</Dialog.Title>
+          <Dialog.Description size="2" color="gray" mb="4">
+            You are logged in as root and are about to delete node{" "}
+            <Text weight="bold">{nodeData?.name}</Text> which belongs to{" "}
+            <Text weight="bold">{nodeData?.organizationName}</Text>, not your own organization.
+            This action <Text weight="bold">cannot be undone</Text>.
+          </Dialog.Description>
+          <Callout.Root color="red" mb="4">
+            <Callout.Icon><ExclamationTriangleIcon /></Callout.Icon>
+            <Callout.Text>You are modifying data that belongs to another organization.</Callout.Text>
+          </Callout.Root>
+          <Flex gap="3" mt="2" justify="end">
+            <Button variant="soft" color="gray" onClick={() => setCrossOrgDialogOpen(false)}>Cancel</Button>
+            <Button color="red" onClick={performDelete}>
+              <TrashIcon /> Confirm deletion
+            </Button>
+          </Flex>
+        </Dialog.Content>
+      </Dialog.Root>
     </FormPageLayout>
   );
 };


### PR DESCRIPTION
- Adjust node dashboard page to allow for changes
- Adjust E2E tests to include the sticky reminder and the text confirmation for node deletion

### Node delete text confirmation:
<img width="517" height="254" alt="Screenshot 2026-05-26 at 08 49 33" src="https://github.com/user-attachments/assets/6341f8e0-b00d-477d-a8e5-513f48c07fd4" />

### Warning for root users:
<img width="510" height="179" alt="Screenshot 2026-05-26 at 08 49 05" src="https://github.com/user-attachments/assets/5bd33f34-7ca9-4c3a-843e-86c7a3934b5e" />


