### PR TITLE
[309] Various fixes and enhancements for admin users

### DIFF
--- a/apps/api/openapi.yaml
+++ b/apps/api/openapi.yaml
@@ -755,6 +755,34 @@ paths:
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
         "404": { $ref: "#/components/responses/NotFound" }
+  /directory/organizations/{oid}/users/{uid}/resend-setup:
+    post:
+      summary: Resend password setup email to a user
+      tags: [Organizations]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: path
+          name: oid
+          required: true
+          schema: { type: integer }
+          description: Organization ID
+        - in: path
+          name: uid
+          required: true
+          schema: { type: integer }
+          description: User ID
+      responses:
+        "200":
+          description: Password setup email sent
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message: { type: string }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
   /directory/organizations/{oid}/users/{uid}:
     get:
       summary: List all users in an organization

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -150,15 +150,6 @@ router.post('/directory/organizations/:id/users', authenticate, context(async (r
   );
 }));
 
-// Retrieve users from the organization
-router.get('/directory/organizations/:id/users', authenticate, context(async (req) => {
-  return req.services.organization.listMembers(
-    req.context,
-    parseInt(req.params.id as string),
-    ListQuery.parse(req.query)
-  );
-}));
-
 router.get('/directory/organizations/:oid/users/:uid', authenticate, context(async (req) => {
   return req.services.organization.getMember(
     req.context,
@@ -171,6 +162,14 @@ router.get('/directory/organizations/check-name/:name', context(async (req) => {
   const organizationName = req.params.name as string;
   const response = await req.services.organization.checkOrganizationExistsByName(organizationName);
   return response;
+}));
+
+router.post('/directory/organizations/:oid/users/:uid/resend-setup', authenticate, context(async (req) => {
+  return req.services.user.resendPasswordSetup(
+    req.context,
+    parseInt(req.params.oid as string),
+    parseInt(req.params.uid as string)
+  );
 }));
 
 router.post('/directory/organizations/:oid/users/:uid', authenticate, context(async (req) => {

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -150,6 +150,15 @@ router.post('/directory/organizations/:id/users', authenticate, context(async (r
   );
 }));
 
+// Retrieve users from the organization
+router.get('/directory/organizations/:id/users', authenticate, context(async (req) => {
+  return req.services.organization.listMembers(
+    req.context,
+    parseInt(req.params.id as string),
+    ListQuery.parse(req.query)
+  );
+}));
+
 router.get('/directory/organizations/:oid/users/:uid', authenticate, context(async (req) => {
   return req.services.organization.getMember(
     req.context,

--- a/apps/api/src/services/user-service.test.ts
+++ b/apps/api/src/services/user-service.test.ts
@@ -7,6 +7,7 @@ import {
   BadRequestError,
   UnauthorizedError,
   NotFoundError,
+  ForbiddenError,
   EmailNotVerifiedError,
 } from '@src/common/errors';
 import { Role } from '@src/common/policies';
@@ -789,7 +790,23 @@ describe('UserService', () => {
       ).rejects.toThrow('Email already in use');
     });
 
+    it('should throw ForbiddenError when user lacks permission for target org', async () => {
+      // context has organizationId: 1 and only 'edit-users' (not 'edit-all-users'),
+      // so targeting a different org (999) must be rejected
+      await expect(
+        userService.addUserToOrganization(context, 999, userData)
+      ).rejects.toThrow(ForbiddenError);
+    });
+
     it('should throw NotFoundError if organization does not exist', async () => {
+      // Use a root context (edit-all-users) so the permission check passes
+      // and the code reaches the org lookup
+      const rootContext = {
+        ...context,
+        role: Role.Root,
+        policies: ['edit-all-users'],
+      };
+
       dbMocks.db.selectFrom = jest
         .fn()
         .mockReturnValueOnce({
@@ -806,7 +823,7 @@ describe('UserService', () => {
         });
 
       await expect(
-        userService.addUserToOrganization(context, 999, userData)
+        userService.addUserToOrganization(rootContext, 999, userData)
       ).rejects.toThrow(NotFoundError);
     });
 
@@ -873,6 +890,114 @@ describe('UserService', () => {
       );
 
       loggerErrorSpy.mockRestore();
+    });
+  });
+
+  describe('resendPasswordSetup', () => {
+    const adminContext = {
+      userId: 1,
+      email: 'admin@example.com',
+      organizationId: 10,
+      role: Role.Administrator,
+      policies: ['edit-users'],
+      status: 'enabled' as const,
+    };
+
+    const mockUser = {
+      id: 2,
+      email: 'jane@example.com',
+      fullName: 'Jane Doe',
+      organizationName: 'Test Org',
+    };
+
+    it('should send a password setup email when admin requests it for a same-org user', async () => {
+      (crypto.randomBytes as jest.Mock).mockReturnValue({
+        toString: jest.fn().mockReturnValue('resetToken123'),
+      });
+
+      dbMocks.db.selectFrom = jest.fn().mockReturnValue({
+        innerJoin: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            where: jest.fn().mockReturnValue({
+              where: jest.fn().mockReturnValue({
+                executeTakeFirst: jest.fn().mockResolvedValue(mockUser),
+              }),
+            }),
+          }),
+        }),
+      });
+
+      dbMocks.db.insertInto = jest.fn().mockReturnValue({
+        values: jest.fn().mockReturnValue({
+          execute: jest.fn().mockResolvedValue(undefined),
+        }),
+      });
+
+      const result = await userService.resendPasswordSetup(adminContext, 10, 2);
+
+      expect(result.message).toBe('Password setup email has been sent.');
+      expect(mockEmailService.sendPasswordSetupEmail).toHaveBeenCalledWith(
+        expect.objectContaining({ to: mockUser.email })
+      );
+    });
+
+    it('should throw ForbiddenError when admin targets a different org', async () => {
+      await expect(
+        userService.resendPasswordSetup(adminContext, 99, 2)
+      ).rejects.toThrow(ForbiddenError);
+    });
+
+    it('should allow root to resend setup for any org', async () => {
+      const rootContext = {
+        ...adminContext,
+        role: Role.Root,
+        policies: ['edit-all-users'],
+        organizationId: 10,
+      };
+
+      (crypto.randomBytes as jest.Mock).mockReturnValue({
+        toString: jest.fn().mockReturnValue('resetToken456'),
+      });
+
+      dbMocks.db.selectFrom = jest.fn().mockReturnValue({
+        innerJoin: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            where: jest.fn().mockReturnValue({
+              where: jest.fn().mockReturnValue({
+                executeTakeFirst: jest.fn().mockResolvedValue(mockUser),
+              }),
+            }),
+          }),
+        }),
+      });
+
+      dbMocks.db.insertInto = jest.fn().mockReturnValue({
+        values: jest.fn().mockReturnValue({
+          execute: jest.fn().mockResolvedValue(undefined),
+        }),
+      });
+
+      const result = await userService.resendPasswordSetup(rootContext, 99, 2);
+
+      expect(result.message).toBe('Password setup email has been sent.');
+    });
+
+    it('should throw NotFoundError when user does not belong to the org', async () => {
+      dbMocks.db.selectFrom = jest.fn().mockReturnValue({
+        innerJoin: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            where: jest.fn().mockReturnValue({
+              where: jest.fn().mockReturnValue({
+                executeTakeFirst: jest.fn().mockResolvedValue(null),
+              }),
+            }),
+          }),
+        }),
+      });
+
+      await expect(
+        userService.resendPasswordSetup(adminContext, 10, 999)
+      ).rejects.toThrow(NotFoundError);
     });
   });
 });

--- a/apps/api/src/services/user-service.ts
+++ b/apps/api/src/services/user-service.ts
@@ -860,7 +860,7 @@ export class UserService {
     // Check if user has permission to add users to this organization
     const allowed = 
       context.policies.includes('edit-all-users') ||
-      context.policies.includes('edit-users') || context.organizationId === organizationId;
+      (context.policies.includes('edit-users') && context.organizationId === organizationId);
     if (!allowed) {
       throw new ForbiddenError('You are not allowed to add users to this organization');
     }
@@ -918,5 +918,43 @@ export class UserService {
       message: 'User created successfully. They will receive an email to set their password.',
       userId: user.id
     };
+  }
+
+  /**
+   * Resend a password setup email to an existing user in an organization.
+   * Admins can use this to let a user (re-)set their password.
+   */
+  async resendPasswordSetup(
+    context: UserContext,
+    organizationId: number,
+    userId: number
+  ): Promise<{ message: string }> {
+    const allowed =
+      context.policies.includes('edit-all-users') ||
+      (context.policies.includes('edit-users') && context.organizationId === organizationId);
+    if (!allowed) {
+      throw new ForbiddenError('You are not allowed to manage users in this organization');
+    }
+
+    const user = await this.db
+      .selectFrom('users')
+      .innerJoin('organizations', 'users.organizationId', 'organizations.id')
+      .select(['users.id', 'users.email', 'users.fullName', 'organizations.name as organizationName'])
+      .where('users.id', '=', userId)
+      .where('users.organizationId', '=', organizationId)
+      .executeTakeFirst();
+
+    if (!user) {
+      throw new NotFoundError('User not found in this organization');
+    }
+
+    await this.generateAndSendPasswordSetupToken(
+      user.id,
+      user.email,
+      user.fullName,
+      user.organizationName
+    );
+
+    return { message: 'Password setup email has been sent.' };
   }
 }

--- a/apps/directory-portal/e2e/mocks/handlers.ts
+++ b/apps/directory-portal/e2e/mocks/handlers.ts
@@ -47,6 +47,7 @@ const mockRegistry: Record<string, MockEntry> = {
   getOrgUsers:             { method: "GET",    pattern: /^\/directory\/organizations\/\d+\/users$/,               defaultResponse: mockUserListResponse },
   getOrgUser:              { method: "GET",    pattern: /^\/directory\/organizations\/\d+\/users\/\d+$/,           defaultResponse: mockUserDetail },
   postOrgUser:             { method: "POST",   pattern: /^\/directory\/organizations\/\d+\/users(\/\d+)?$/,        defaultResponse: mockUserDetail },
+  postResendSetup:         { method: "POST",   pattern: /^\/directory\/organizations\/\d+\/users\/\d+\/resend-setup$/, defaultResponse: { message: "Password setup email has been sent." } },
 
   // Nodes
   getOrgNodes:             { method: "GET",    pattern: /^\/directory\/organizations\/\d+\/nodes$/,               defaultResponse: mockNodeListResponse },

--- a/apps/directory-portal/e2e/organizations.spec.ts
+++ b/apps/directory-portal/e2e/organizations.spec.ts
@@ -123,6 +123,76 @@ test.describe("Organizations", () => {
     await expect(nameInput).toHaveValue("Test User");
   });
 
+  test("edit user slide-over shows Reset Password button", async ({
+    authenticatedPage: page,
+  }) => {
+    await page.goto("/organization/users");
+
+    await page.getByRole("button", { name: "Edit User Details" }).first().click();
+
+    await expect(page.getByRole("button", { name: /reset password/i })).toBeVisible();
+  });
+
+  test("add user slide-over does not show Reset Password button", async ({
+    authenticatedPage: page,
+  }) => {
+    await page.goto("/organization/users");
+
+    await page.getByRole("button", { name: /add user/i }).click();
+
+    await expect(page.getByRole("textbox", { name: /email/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /reset password/i })).not.toBeVisible();
+  });
+
+  test("Reset Password button calls resend-setup API and shows confirmation", async ({
+    authenticatedPage: page,
+  }) => {
+    let resendCalled = false;
+    const apiBase = process.env.API_BASE_URL ?? "http://localhost:3010/api";
+
+    await page.route(`${apiBase}/directory/organizations/10/users/1/resend-setup`, async (route) => {
+      if (route.request().method() === "POST") {
+        resendCalled = true;
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ message: "Password setup email has been sent." }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.goto("/organization/users");
+    await page.getByRole("button", { name: "Edit User Details" }).first().click();
+
+    await page.getByRole("button", { name: /reset password/i }).click();
+
+    await expect(page.getByRole("button", { name: /email sent/i })).toBeVisible();
+    expect(resendCalled).toBe(true);
+  });
+
+  test("Reset Password button shows failure message on API error", async ({
+    authenticatedPage: page,
+  }) => {
+    const apiBase = process.env.API_BASE_URL ?? "http://localhost:3010/api";
+
+    await page.route(`${apiBase}/directory/organizations/10/users/1/resend-setup`, async (route) => {
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "Internal server error" }),
+      });
+    });
+
+    await page.goto("/organization/users");
+    await page.getByRole("button", { name: "Edit User Details" }).first().click();
+
+    await page.getByRole("button", { name: /reset password/i }).click();
+
+    await expect(page.getByRole("button", { name: /failed.*try again/i })).toBeVisible();
+  });
+
   test("selecting a user shows Enable/Disable bulk action buttons", async ({
     authenticatedPage: page,
   }) => {

--- a/apps/directory-portal/src/components/UserForm.tsx
+++ b/apps/directory-portal/src/components/UserForm.tsx
@@ -11,6 +11,7 @@ import {
 import {
   ExclamationTriangleIcon,
   CheckIcon,
+  EnvelopeOpenIcon,
 } from "@radix-ui/react-icons";
 import { fetchWithAuth } from "../utils/auth-fetch";
 import { useAuth } from "../contexts/AuthContext";
@@ -52,6 +53,8 @@ const UserForm: React.FC<UserFormProps> = ({
   const [errorMessage, setErrorMessage] = useState("");
   const [loading, setLoading] = useState(isEditMode);
   const [submitting, setSubmitting] = useState(false);
+  const [resendStatus, setResendStatus] = useState<null | "success" | "error">(null);
+  const [resendLoading, setResendLoading] = useState(false);
 
   // Load existing user data for edit mode
   const loadUser = useCallback(async () => {
@@ -133,6 +136,23 @@ const UserForm: React.FC<UserFormProps> = ({
 
   const handleRoleChange = (value: string) => {
     setFormData((prev) => ({ ...prev, role: value }));
+  };
+
+  const handleResendPasswordSetup = async () => {
+    if (!isEditMode) return;
+    try {
+      setResendLoading(true);
+      setResendStatus(null);
+      const response = await fetchWithAuth(
+        `/organizations/${organizationId}/users/${userId}/resend-setup`,
+        { method: "POST" }
+      );
+      setResendStatus(response!.ok ? "success" : "error");
+    } catch {
+      setResendStatus("error");
+    } finally {
+      setResendLoading(false);
+    }
   };
 
   const organizationName =
@@ -229,10 +249,27 @@ const UserForm: React.FC<UserFormProps> = ({
       </FormField>
 
       {/* Actions */}
-      <Flex gap="3" mt="2" justify="end">
+      <Flex gap="3" mt="2" justify="end" wrap="wrap">
         {onCancel && (
           <Button type="button" color="jade" onClick={onCancel}>
             Cancel
+          </Button>
+        )}
+        {isEditMode && (
+          <Button
+            type="button"
+            variant="soft"
+            color="amber"
+            disabled={resendLoading}
+            onClick={handleResendPasswordSetup}
+            title="Send the user an email to (re-)set their password"
+          >
+            {resendLoading ? <Spinner loading /> : <EnvelopeOpenIcon />}
+            {resendStatus === "success"
+              ? "Email sent!"
+              : resendStatus === "error"
+                ? "Failed — try again"
+                : "Reset Password"}
           </Button>
         )}
         <Form.Submit asChild>


### PR DESCRIPTION
1. Security bug fix: Added parentheses so edit-users policy is required alongside the org-ID check. Previously any authenticated user in the same org could invite members.
2. An admin can now initiate the reset password flow for any user in their own organization.

<img width="446" height="201" alt="Screenshot 2026-06-01 at 11 19 17" src="https://github.com/user-attachments/assets/0fbdaec2-b77b-4804-8aa4-6bbb5706f8b3" />
