### PR TITLE
[Bugfix] Fix sticky root notification taking vertical scroll space

### DIFF
--- a/packages/directory-portal/src/layouts/FunctionalPageLayout.tsx
+++ b/packages/directory-portal/src/layouts/FunctionalPageLayout.tsx
@@ -46,11 +46,6 @@ const FunctionalPageLayout: React.FC<FunctionalPageLayoutProps> = ({
             <img height={32} src={pactLogo} alt="PACT Logo" />
           </picture>
         </div>
-        <div className="top-bar-right">
-          <SignUp />
-        </div>
-      </header>
-
       {isRoot && (
         <Callout.Root color="amber" variant="surface" style={{ borderRadius: 0, position: "sticky", top: 0, zIndex: 100 }}>
           <Callout.Icon>
@@ -62,6 +57,12 @@ const FunctionalPageLayout: React.FC<FunctionalPageLayoutProps> = ({
           </Callout.Text>
         </Callout.Root>
       )}
+
+
+        <div className="top-bar-right">
+          <SignUp />
+        </div>
+      </header>
 
       <div className="container">
         {mobileMenuOpen && (


### PR DESCRIPTION
Move the sticky bar in the header

<img width="1081" height="367" alt="Screenshot 2026-06-10 at 12 02 45" src="https://github.com/user-attachments/assets/08accdba-8fda-4275-8830-dfe02ea5b23b" />
