### PR TITLE
Set up pipelines for publishing pact-api and pact-data-model

### DIFF
--- a/.github/workflows/publish-pact-api-client.yml
+++ b/.github/workflows/publish-pact-api-client.yml
@@ -1,0 +1,41 @@
+name: Publish @wbcsd/pact-api-client
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Dry run (skip actual publish)"
+        type: boolean
+        default: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build pact-data-model
+        run: npm run build -w packages/pact-data-model
+
+      - name: Build pact-api-client
+        run: npm run build -w packages/pact-api-client
+
+      - name: Publish to npm
+        uses: JS-DevTools/npm-publish@v4
+        with:
+          package: packages/pact-api-client
+          access: public
+          dry-run: ${{ inputs.dry-run }}

--- a/.github/workflows/publish-pact-data-model.yml
+++ b/.github/workflows/publish-pact-data-model.yml
@@ -1,0 +1,38 @@
+name: Publish @wbcsd/pact-data-model
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Dry run (skip actual publish)"
+        type: boolean
+        default: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build -w packages/pact-data-model
+
+      - name: Publish to npm
+        uses: JS-DevTools/npm-publish@v4
+        with:
+          package: packages/pact-data-model
+          access: public
+          dry-run: ${{ inputs.dry-run }}


### PR DESCRIPTION
Creates two independent pipelines, manually triggered for now, for publishing pact-api and pact-data-model to npmjs.