### PR TITLE
Fixes an issue where untrusted event.source were not checked

### DIFF
--- a/packages/api/src/routes/internal-node-routes.ts
+++ b/packages/api/src/routes/internal-node-routes.ts
@@ -1,5 +1,6 @@
 import { Router, Request, Response, NextFunction } from "express";
 import { Services } from "../services";
+import { InternalNodeTokenPayload } from "../services/internal-node-auth-service";
 import {
    BadRequestError as BaseBadRequestError, 
    NotFoundError as BaseNotFoundError, 
@@ -196,6 +197,8 @@ export function createInternalNodeRoutes(): Router {
       eventSource: req.body.source,
     }, "Received PACT event for internal node");
 
+    const nodeAuth = res.locals.nodeAuth as InternalNodeTokenPayload | undefined;
+
     await req.services.internalNodePact.handleEvent(req.nodeId, {
       type: req.body.type,
       specversion: req.body.specversion,
@@ -203,7 +206,7 @@ export function createInternalNodeRoutes(): Router {
       source: req.body.source,
       time: req.body.time,
       data: req.body.data,
-    });
+    }, nodeAuth?.nodeId ?? null);
 
     res.status(200).send();
   }));

--- a/packages/api/src/services/internal-node-pact-service.test.ts
+++ b/packages/api/src/services/internal-node-pact-service.test.ts
@@ -462,6 +462,23 @@ describe('InternalNodePactService', () => {
     });
 
     describe('RequestCreatedEvent (Test Case #12)', () => {
+      it('stores requester node from authenticated context, not from event.source', async () => {
+        await service.handleEvent(
+          nodeId,
+          {
+            ...baseEvent,
+            type: EventTypes.RequestCreated,
+            source: 'https://attacker.example.com/api/nodes/99999',
+            data: { productId: ['urn:gtin:1234567890123'] },
+          },
+          14
+        );
+
+        const valuesCall = dbMocks.queryChain.values.mock.calls.find((args) => !!args[0]);
+        expect(valuesCall).toBeDefined();
+        expect(valuesCall![0].fromNodeId).toBe(14);
+      });
+
       it('should acknowledge and trigger async callback for RequestCreatedEvent', async () => {
         // Mock: no matching footprints found
         dbMocks.executors.execute.mockResolvedValueOnce([]);

--- a/packages/api/src/services/internal-node-pact-service.ts
+++ b/packages/api/src/services/internal-node-pact-service.ts
@@ -92,7 +92,8 @@ export class InternalNodePactService {
    */
   public async handleEvent(
     nodeId: number,
-    event: BaseEvent
+    event: BaseEvent,
+    requesterNodeId: number | null = null
   ) {
     const { type, id, source, data } = event;
 
@@ -120,10 +121,16 @@ export class InternalNodePactService {
 
       case EventTypes.RequestCreated: {
         logger.info(
-          { nodeId, eventId: id, source, productId: data?.productId },
+          { nodeId, eventId: id, source, requesterNodeId, productId: data?.productId },
           'Received RequestCreatedEvent for internal node — saving to inbox'
         );
-        await this.handleRequestCreatedEvent(nodeId, id, source, event as RequestCreatedEvent);
+        await this.handleRequestCreatedEvent(
+          nodeId,
+          id,
+          source,
+          requesterNodeId,
+          event as RequestCreatedEvent
+        );
         break;
       }
 
@@ -214,20 +221,16 @@ export class InternalNodePactService {
     nodeId: number,
     requestEventId: string,
     source: string,
+    requesterNodeId: number | null,
     event: RequestCreatedEvent
   ): Promise<void> {
     const filters = event.data as FootprintFilters;
-
-    // Parse fromNodeId from source URL if it's a directory-internal node
-    // e.g. "http://localhost:3010/api/nodes/14" → 14
-    const fromNodeMatch = source.match(/\/api\/nodes\/(\d+)/);
-    const fromNodeId = fromNodeMatch ? parseInt(fromNodeMatch[1], 10) : null;
 
     await this.db
       .insertInto('pcf_requests')
       .values({
         targetNodeId: nodeId,
-        fromNodeId,
+        fromNodeId: requesterNodeId,
         connectionId: null,
         source,
         requestEventId,
@@ -240,7 +243,7 @@ export class InternalNodePactService {
       .onConflict((oc) => oc.columns(['source','requestEventId']).doNothing())
       .execute();
       
-    logger.info({ nodeId, requestEventId, fromNodeId }, 'Incoming PCF request saved to inbox');
+    logger.info({ nodeId, requestEventId, fromNodeId: requesterNodeId }, 'Incoming PCF request saved to inbox');
   }
 
   /**

--- a/packages/api/src/services/pcf-request-service.test.ts
+++ b/packages/api/src/services/pcf-request-service.test.ts
@@ -503,16 +503,19 @@ describe('PcfRequestService', () => {
   // fulfill()
   // ──────────────────────────────────────────────────
   describe('fulfill()', () => {
-    // fromNodeId=null skips the local-node direct-write path, keeping most tests isolated.
-    // Tests that cover the direct-write path use a separate fixture with a known fromNodeId.
     const mockIncomingRequest = {
       id: 10,
-      fromNodeId: null,
+      fromNodeId: 888,
       targetNodeId: nodeId,
       requestEventId: 'req-ev-001',
       source: `${DIRECTORY_API}/api/nodes/888`,
       status: 'pending',
       filters: { geography: ['US'] },
+    };
+
+    const mockRequesterNode = {
+      id: 888,
+      apiUrl: 'https://requester.example.com/api/nodes/888',
     };
 
     // Use the real silversurfer23 US laptop row — DB row id ≠ PACT data id
@@ -541,6 +544,7 @@ describe('PcfRequestService', () => {
       nodeService.get.mockResolvedValueOnce(mockFromNode as any);
       dbMocks.executors.executeTakeFirst
         .mockResolvedValueOnce(mockIncomingRequest)
+        .mockResolvedValueOnce(mockRequesterNode)
         .mockResolvedValueOnce(mockReverseConnection);
       dbMocks.executors.execute
         .mockResolvedValueOnce([mockFootprintRow])  // footprint lookup
@@ -575,6 +579,7 @@ describe('PcfRequestService', () => {
       nodeService.get.mockResolvedValueOnce(mockFromNode as any);
       dbMocks.executors.executeTakeFirst
         .mockResolvedValueOnce(mockIncomingRequest)
+        .mockResolvedValueOnce(mockRequesterNode)
         .mockResolvedValueOnce(mockReverseConnection);
       dbMocks.executors.execute
         .mockResolvedValueOnce([mockFootprintRow])
@@ -600,6 +605,7 @@ describe('PcfRequestService', () => {
       nodeService.get.mockResolvedValueOnce(mockFromNode as any);
       dbMocks.executors.executeTakeFirst
         .mockResolvedValueOnce(mockIncomingRequest)
+        .mockResolvedValueOnce(mockRequesterNode)
         .mockResolvedValueOnce(mockReverseConnection);
       dbMocks.executors.execute
         .mockResolvedValueOnce([mockFootprintRow])
@@ -619,6 +625,7 @@ describe('PcfRequestService', () => {
       nodeService.get.mockResolvedValueOnce(mockFromNode as any);
       dbMocks.executors.executeTakeFirst
         .mockResolvedValueOnce(mockIncomingRequest)
+        .mockResolvedValueOnce(mockRequesterNode)
         .mockResolvedValueOnce(mockReverseConnection);
       dbMocks.executors.execute
         .mockResolvedValueOnce([{ data: ss23SteelData }, { data: ss23ContainerData }])
@@ -643,6 +650,7 @@ describe('PcfRequestService', () => {
       nodeService.get.mockResolvedValueOnce(mockFromNode as any);
       dbMocks.executors.executeTakeFirst
         .mockResolvedValueOnce(mockIncomingRequest)
+        .mockResolvedValueOnce(mockRequesterNode)
         .mockResolvedValueOnce(mockReverseConnection);
       dbMocks.executors.execute
         .mockResolvedValueOnce([mockFootprintRow])
@@ -655,7 +663,7 @@ describe('PcfRequestService', () => {
 
     it('marks fulfilled even when source URL is null (no callback sent)', async () => {
       jest.clearAllMocks();
-      const noSourceRequest = { ...mockIncomingRequest, source: null };
+      const noSourceRequest = { ...mockIncomingRequest, source: null, fromNodeId: null };
 
       nodeService.get.mockResolvedValueOnce(mockFromNode as any);
       dbMocks.executors.executeTakeFirst.mockResolvedValueOnce(noSourceRequest);
@@ -718,6 +726,7 @@ describe('PcfRequestService', () => {
       nodeService.get.mockResolvedValueOnce(mockFromNode as any);
       dbMocks.executors.executeTakeFirst
         .mockResolvedValueOnce(localRequest)          // load pcf_request
+        .mockResolvedValueOnce(mockRequesterNode)     // resolveTrustedCallbackUrl
         .mockResolvedValueOnce(mockReverseConnection) // getCallbackToken: reverse connection
         .mockResolvedValueOnce({ id: localFromNodeId }) // node existence check
         .mockResolvedValueOnce(null);                 // no existing product_footprints row
@@ -751,6 +760,7 @@ describe('PcfRequestService', () => {
       nodeService.get.mockResolvedValueOnce(mockFromNode as any);
       dbMocks.executors.executeTakeFirst
         .mockResolvedValueOnce(localRequest)
+        .mockResolvedValueOnce(mockRequesterNode)
         .mockResolvedValueOnce(mockReverseConnection)
         .mockResolvedValueOnce({ id: localFromNodeId });      // node exists
       dbMocks.executors.execute
@@ -772,6 +782,7 @@ describe('PcfRequestService', () => {
       nodeService.get.mockResolvedValueOnce(mockFromNode as any);
       dbMocks.executors.executeTakeFirst
         .mockResolvedValueOnce(mockIncomingRequest)
+        .mockResolvedValueOnce(mockRequesterNode)
         .mockResolvedValueOnce(mockReverseConnection);
       dbMocks.executors.execute
         .mockResolvedValueOnce([mockFootprintRow])
@@ -805,6 +816,11 @@ describe('PcfRequestService', () => {
       clientSecret: Buffer.from('cb-secret').toString('base64'),
     };
 
+    const mockRequesterNode = {
+      id: 888,
+      apiUrl: 'https://requester.example.com/api/nodes/888',
+    };
+
     beforeEach(() => {
       mockFetch
         .mockResolvedValueOnce({
@@ -818,6 +834,7 @@ describe('PcfRequestService', () => {
       nodeService.get.mockResolvedValueOnce(mockFromNode as any);
       dbMocks.executors.executeTakeFirst
         .mockResolvedValueOnce(mockIncomingRequest)
+        .mockResolvedValueOnce(mockRequesterNode)
         .mockResolvedValueOnce(mockReverseConnection);
       dbMocks.executors.execute.mockResolvedValueOnce(undefined); // UPDATE
 
@@ -844,6 +861,7 @@ describe('PcfRequestService', () => {
       nodeService.get.mockResolvedValueOnce(mockFromNode as any);
       dbMocks.executors.executeTakeFirst
         .mockResolvedValueOnce(mockIncomingRequest)
+        .mockResolvedValueOnce(mockRequesterNode)
         .mockResolvedValueOnce(mockReverseConnection);
       dbMocks.executors.execute.mockResolvedValueOnce(undefined);
 
@@ -852,7 +870,7 @@ describe('PcfRequestService', () => {
 
     it('marks rejected even when source URL is null', async () => {
       jest.clearAllMocks();
-      const noSourceRequest = { ...mockIncomingRequest, source: null };
+      const noSourceRequest = { ...mockIncomingRequest, source: null, fromNodeId: null };
 
       nodeService.get.mockResolvedValueOnce(mockFromNode as any);
       dbMocks.executors.executeTakeFirst.mockResolvedValueOnce(noSourceRequest);

--- a/packages/api/src/services/pcf-request-service.ts
+++ b/packages/api/src/services/pcf-request-service.ts
@@ -8,6 +8,7 @@ import { NodeConnectionService } from './node-connection-service';
 import { PactApiClient, FootprintFilters } from '@wbcsd/pact-api-client';
 import { EventTypes } from '@wbcsd/pact-data-model/v3_0';
 import logger from '@src/common/logger';
+import net from 'net';
 
 export interface PcfRequestData {
   id: number;
@@ -313,10 +314,8 @@ export class PcfRequestService {
 
     const footprints = footprintRows.map((r) => r.data);
 
-    // Send RequestFulfilledEvent callback
-    const callbackUrl = request.source
-      ? (request.source.endsWith('/3/events') ? request.source : `${request.source.replace(/\/+$/, '')}/3/events`)
-      : null;
+    // Send RequestFulfilledEvent callback using trusted node metadata.
+    const callbackUrl = await this.resolveTrustedCallbackUrl(nodeId, request.fromNodeId ?? null);
 
     if (callbackUrl) {
       const authToken = await this.getCallbackToken(nodeId, request.fromNodeId ?? null);
@@ -429,9 +428,7 @@ export class PcfRequestService {
       throw new NotFoundError('Pending incoming PCF request not found');
     }
 
-    const callbackUrl = request.source
-      ? (request.source.endsWith('/3/events') ? request.source : `${request.source.replace(/\/+$/, '')}/3/events`)
-      : null;
+    const callbackUrl = await this.resolveTrustedCallbackUrl(nodeId, request.fromNodeId ?? null);
 
     if (callbackUrl) {
       const authToken = await this.getCallbackToken(nodeId, request.fromNodeId ?? null);
@@ -518,6 +515,102 @@ export class PcfRequestService {
       logger.warn({ nodeId, fromNodeId, error: (err as Error).message }, 'Error obtaining callback auth token');
       return '';
     }
+  }
+
+  private async resolveTrustedCallbackUrl(
+    targetNodeId: number,
+    fromNodeId: number | null
+  ): Promise<string | null> {
+    if (!fromNodeId) {
+      return null;
+    }
+
+    const requesterNode = await this.db
+      .selectFrom('nodes')
+      .select(['id', 'apiUrl'])
+      .where('id', '=', fromNodeId)
+      .executeTakeFirst();
+
+    if (!requesterNode) {
+      logger.warn({ targetNodeId, fromNodeId }, 'Requester node not found — skipping callback');
+      return null;
+    }
+
+    const callbackBase = requesterNode.apiUrl
+      ? requesterNode.apiUrl.replace(/\/+$/, '')
+      : `${this.directoryApiBaseUrl}/api/nodes/${fromNodeId}`;
+
+    const callbackUrl = callbackBase.endsWith('/3/events')
+      ? callbackBase
+      : `${callbackBase}/3/events`;
+
+    if (!this.isSafeCallbackUrl(callbackUrl)) {
+      logger.warn(
+        { targetNodeId, fromNodeId, callbackUrl },
+        'Unsafe callback URL rejected — skipping callback'
+      );
+      return null;
+    }
+
+    return callbackUrl;
+  }
+
+  private isSafeCallbackUrl(urlString: string): boolean {
+    try {
+      const callbackUrl = new URL(urlString);
+      const directoryOrigin = new URL(this.directoryApiBaseUrl).origin;
+
+      // Strict by default: only HTTPS callbacks unless using our own directory origin.
+      if (callbackUrl.protocol !== 'https:' && callbackUrl.origin !== directoryOrigin) {
+        return false;
+      }
+
+      if (callbackUrl.origin === directoryOrigin) {
+        return true;
+      }
+
+      const host = callbackUrl.hostname.toLowerCase();
+      if (host === 'localhost' || host.endsWith('.localhost') || host === '127.0.0.1' || host === '::1') {
+        return false;
+      }
+
+      const ipVersion = net.isIP(host);
+      if (ipVersion === 4 && this.isPrivateIpv4(host)) {
+        return false;
+      }
+
+      if (ipVersion === 6 && this.isPrivateOrLocalIpv6(host)) {
+        return false;
+      }
+
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private isPrivateIpv4(ip: string): boolean {
+    const [a, b] = ip.split('.').map(Number);
+    if ([a, b].some((n) => Number.isNaN(n))) {
+      return true;
+    }
+
+    if (a === 10 || a === 127 || a === 0) return true;
+    if (a === 169 && b === 254) return true;
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    if (a === 192 && b === 168) return true;
+
+    return false;
+  }
+
+  private isPrivateOrLocalIpv6(ip: string): boolean {
+    const normalized = ip.toLowerCase();
+    return (
+      normalized === '::1' ||
+      normalized.startsWith('fc') ||
+      normalized.startsWith('fd') ||
+      normalized.startsWith('fe80')
+    );
   }
 
   private decryptSecret(encrypted: string): string {


### PR DESCRIPTION
- Untrusted event.source no longer controls fromNodeId persistence.
- Callback egress no longer uses attacker-controlled source.
- Bearer token issuance path is tied to trusted fromNodeId context and callback destination is resolved from server-managed node metadata with URL safety checks.