### PR TITLE
Add tiered PCF measuring for PCF form in Nodes

### DIFF
--- a/packages/directory-portal/e2e/footprints.spec.ts
+++ b/packages/directory-portal/e2e/footprints.spec.ts
@@ -61,7 +61,7 @@ test.describe("Product Footprints", () => {
   }) => {
     await page.goto("/nodes/100/footprints/new");
 
-    await expect(page.getByRole("button", { name: /submit|save|add/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /save product footprint/i })).toBeVisible();
   });
 
   test("add footprint — submitting an empty form shows validation errors", async ({
@@ -69,10 +69,10 @@ test.describe("Product Footprints", () => {
   }) => {
     await page.goto("/nodes/100/footprints/new");
 
-    await page.getByRole("button", { name: /submit|save|add/i }).click();
+    await page.getByRole("button", { name: /save product footprint/i }).click();
 
     // Form validation should keep the form visible and show required field indicators
-    await expect(page.getByRole("button", { name: /submit|save|add/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /save product footprint/i })).toBeVisible();
   });
 
   test("add footprint — success shows the new PCF ID and copy buttons", async ({
@@ -96,7 +96,7 @@ test.describe("Product Footprints", () => {
       await productDescField.fill("E2E Test Product");
     }
 
-    await page.getByRole("button", { name: /submit|save|add/i }).click();
+    await page.getByRole("button", { name: /save product footprint/i }).click();
 
     // After success, should show the created footprint's UUID and copy buttons
     // or navigate — either way, no error should be shown

--- a/packages/directory-portal/e2e/pcf-level.spec.ts
+++ b/packages/directory-portal/e2e/pcf-level.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect } from "./fixtures";
+import type { Page } from "@playwright/test";
+
+/**
+ * Verifies the PCF Usability Level badge climbs from "Incomplete" through
+ * Level 1 → 2 → 3 as the Add Product Footprint form is progressively filled in.
+ *
+ * The badge in the form panel carries data-testid="pcf-level-badge" and its
+ * text is the achieved level label ("Incomplete" / "Level 1" / …).
+ */
+test.describe("PCF Usability Level — live badge on the Add form", () => {
+  /** Add a value to a TagInput (custom component) by typing and pressing Enter. */
+  async function addTag(page: Page, placeholder: string, value: string) {
+    const input = page.getByPlaceholder(placeholder);
+    await input.fill(value);
+    await input.press("Enter");
+  }
+
+  /** Fill the Level 1 (Indicative) attributes: core identity, unit, cradle-to-gate value, reference period, geography. */
+  async function fillLevel1(page: Page) {
+    await page.getByLabel(/product trade name/i).fill("E2E Widget");
+    await page.getByLabel(/product description/i).fill("An end-to-end test widget");
+    await addTag(page, "urn:gtin:4012345678901", "urn:gtin:4012345678901");
+    await page.getByLabel(/pcf excl\. biogenic uptake/i).fill("5.14");
+    await page.getByLabel(/declared unit amount/i).fill("1.0");
+    await page.getByLabel(/mass per declared unit/i).fill("1.0");
+    await page.getByLabel(/reference period start/i).fill("2024-01-01");
+    await page.getByLabel(/reference period end/i).fill("2024-12-31");
+    await page.getByLabel(/country \(iso 3166-1/i).fill("DE");
+  }
+
+  /** Fill the Level 2 (Consistent) attributes: biogenic-inclusive value, PDS, secondary emission factor sources. */
+  async function fillLevel2(page: Page) {
+    await page.getByLabel(/pcf incl\. biogenic uptake/i).fill("4.90");
+    await page.getByLabel(/primary data share/i).fill("60");
+    // Secondary emission factor sources (repeatable name/version editor).
+    await page.getByRole("button", { name: /add source/i }).click();
+    await page.getByPlaceholder("Database name (e.g. ecoinvent)").fill("ecoinvent");
+    await page.getByPlaceholder("Version (e.g. 3.9.1)").fill("3.9.1");
+  }
+
+  /** Fill the Level 3 (Methodologically Complete) attributes: remaining SHALL fields + transparency. */
+  async function fillLevel3(page: Page) {
+    await page.getByLabel(/company name/i).fill("E2E Test Company");
+    await addTag(page, "urn:company:example:company1", "urn:company:example:co1");
+    await page.getByLabel(/fossil ghg emissions/i).fill("3.20");
+    await page.getByLabel(/fossil carbon content/i).fill("0.50");
+    // Keep exemptions <= 3% so the exemption description is not required.
+    await page.getByLabel(/exempted emissions \(%\)/i).fill("2.0");
+    await page.getByLabel(/allocation rules description/i).fill("Mass-based allocation");
+    await page.getByLabel(/boundary processes description/i).fill("Cradle-to-gate manufacturing");
+  }
+
+  test("badge progresses Incomplete → Level 1 → Level 2 → Level 3", async ({
+    authenticatedPage: page,
+  }) => {
+    await page.goto("/nodes/100/footprints/new");
+
+    const badge = page.getByTestId("pcf-level-badge");
+
+    // A brand-new form has core identity fields empty -> below Level 1.
+    await expect(badge).toHaveText("Incomplete");
+
+    await fillLevel1(page);
+    await expect(badge).toHaveText("Level 1");
+
+    await fillLevel2(page);
+    await expect(badge).toHaveText("Level 2");
+
+    await fillLevel3(page);
+    await expect(badge).toHaveText("Level 3");
+  });
+
+  test("level does not advance while a lower tier is incomplete", async ({
+    authenticatedPage: page,
+  }) => {
+    await page.goto("/nodes/100/footprints/new");
+
+    const badge = page.getByTestId("pcf-level-badge");
+    await expect(badge).toHaveText("Incomplete");
+
+    // Fill Level 2 and Level 3 attributes but leave a Level 1 attribute (geography) blank.
+    await page.getByLabel(/product trade name/i).fill("E2E Widget");
+    await page.getByLabel(/product description/i).fill("An end-to-end test widget");
+    await addTag(page, "urn:gtin:4012345678901", "urn:gtin:4012345678901");
+    await page.getByLabel(/pcf excl\. biogenic uptake/i).fill("5.14");
+    await page.getByLabel(/declared unit amount/i).fill("1.0");
+    await page.getByLabel(/mass per declared unit/i).fill("1.0");
+    await page.getByLabel(/reference period start/i).fill("2024-01-01");
+    await page.getByLabel(/reference period end/i).fill("2024-12-31");
+    // Geography intentionally left blank -> Level 1 incomplete.
+
+    await fillLevel2(page);
+    await fillLevel3(page);
+
+    // A Level 1 gap caps the level even though Level 2/3 fields are populated.
+    await expect(badge).toHaveText("Incomplete");
+
+    // Filling the missing Level 1 attribute unlocks the full Level 3.
+    await page.getByLabel(/country \(iso 3166-1/i).fill("DE");
+    await expect(badge).toHaveText("Level 3");
+  });
+});

--- a/packages/directory-portal/src/components/PcfLevelBadge.tsx
+++ b/packages/directory-portal/src/components/PcfLevelBadge.tsx
@@ -1,0 +1,183 @@
+import React from "react";
+import { Badge, Box, Flex, HoverCard, Text } from "@radix-ui/themes";
+import { CheckCircledIcon, CrossCircledIcon } from "@radix-ui/react-icons";
+import {
+  computePcfLevel,
+  PcfLevelResult,
+  TierStatus,
+} from "../utils/pcf-level";
+import { ProductFootprint } from "pact-data-model/v3_0";
+
+type FootprintLike =
+  | Partial<ProductFootprint>
+  | Record<string, unknown>
+  | null
+  | undefined;
+
+interface PcfLevelBadgeProps {
+  /** The footprint to evaluate. Ignored when `result` is provided. */
+  footprint?: FootprintLike;
+  /** Pre-computed level result (avoids recomputation when already available). */
+  result?: PcfLevelResult;
+  size?: "1" | "2" | "3";
+  /** Show the tier breakdown on hover. Defaults to true. */
+  withDetails?: boolean;
+}
+
+function TierRow({ status }: { status: TierStatus }) {
+  return (
+    <Flex align="center" justify="between" gap="3">
+      <Flex align="center" gap="2">
+        {status.complete ? (
+          <CheckCircledIcon color="var(--green-9)" />
+        ) : (
+          <CrossCircledIcon color="var(--gray-8)" />
+        )}
+        <Text size="2" weight={status.complete ? "medium" : "regular"}>
+          Level {status.tier.level} · {status.tier.title}
+        </Text>
+      </Flex>
+      <Text size="1" color="gray">
+        {status.populatedCount}/{status.totalCount}
+      </Text>
+    </Flex>
+  );
+}
+
+/**
+ * Visual indicator for the PCF Usability Model level (1/2/3).
+ * Renders a coloured badge; on hover it reveals the per-tier completion
+ * breakdown and the fields still missing for the next level.
+ */
+const PcfLevelBadge: React.FC<PcfLevelBadgeProps> = ({
+  footprint,
+  result,
+  size = "2",
+  withDetails = true,
+}) => {
+  const level = result ?? computePcfLevel(footprint);
+
+  const badge = (
+    <Badge
+      color={level.color}
+      size={size}
+      variant="soft"
+      data-testid="pcf-level-badge"
+      data-level={level.level}
+      style={{ cursor: withDetails ? "help" : "default" }}
+    >
+      {level.label}
+    </Badge>
+  );
+
+  if (!withDetails) return badge;
+
+  const nextIncomplete = level.tiers.find((t) => !t.complete);
+
+  return (
+    <HoverCard.Root>
+      <HoverCard.Trigger>
+        <span>{badge}</span>
+      </HoverCard.Trigger>
+      <HoverCard.Content size="2" maxWidth="340px">
+        <Flex direction="column" gap="3">
+          <Box>
+            <Text as="div" size="2" weight="bold">
+              PCF Usability Level
+            </Text>
+            <Text as="div" size="1" color="gray">
+              Reflects which categorised disclosure fields are populated.
+            </Text>
+          </Box>
+
+          <Flex direction="column" gap="2">
+            {level.tiers.map((status) => (
+              <TierRow key={status.tier.key} status={status} />
+            ))}
+          </Flex>
+
+          {nextIncomplete && (
+            <Box>
+              <Text as="div" size="1" weight="medium" mb="1">
+                Missing for Level {nextIncomplete.tier.level}:
+              </Text>
+              <Text as="div" size="1" color="gray">
+                {nextIncomplete.missingFields
+                  .map((field) => field.label)
+                  .join(", ")}
+              </Text>
+            </Box>
+          )}
+        </Flex>
+      </HoverCard.Content>
+    </HoverCard.Root>
+  );
+};
+
+interface PcfLevelPanelProps {
+  footprint?: FootprintLike;
+  result?: PcfLevelResult;
+}
+
+/**
+ * Inline panel summarising the PCF Usability Model level, intended for the
+ * read-only footprint detail view. Shows the achieved level plus a checklist
+ * of each tier's completion.
+ */
+export const PcfLevelPanel: React.FC<PcfLevelPanelProps> = ({
+  footprint,
+  result,
+}) => {
+  const level = result ?? computePcfLevel(footprint);
+
+  return (
+    <Box
+      p="3"
+      mb="2"
+      style={{
+        border: "1px solid var(--gray-4)",
+        borderRadius: "var(--radius-3)",
+        background: "var(--gray-1)",
+      }}
+    >
+      <Flex align="center" justify="between" gap="3" mb="3" wrap="wrap">
+        <Flex align="center" gap="2">
+          <Text size="2" weight="bold">
+            PCF Usability Level
+          </Text>
+          <PcfLevelBadge result={level} withDetails={false} />
+        </Flex>
+        <Text size="1" color="gray">
+          Derived from which categorised disclosure fields are populated.
+        </Text>
+      </Flex>
+
+      <Flex direction="column" gap="2">
+        {level.tiers.map((status) => (
+          <Flex key={status.tier.key} align="center" justify="between" gap="3">
+            <Flex align="center" gap="2">
+              {status.complete ? (
+                <CheckCircledIcon color="var(--green-9)" />
+              ) : (
+                <CrossCircledIcon color="var(--gray-8)" />
+              )}
+              <Box>
+                <Text as="div" size="2" weight={status.complete ? "medium" : "regular"}>
+                  Level {status.tier.level} · {status.tier.title}
+                </Text>
+                <Text as="div" size="1" color="gray">
+                  {status.tier.description}
+                </Text>
+              </Box>
+            </Flex>
+            <Text size="1" color={status.complete ? "green" : "gray"}>
+              {status.populatedCount}/{status.totalCount}
+            </Text>
+          </Flex>
+        ))}
+      </Flex>
+    </Box>
+  );
+};
+
+export default PcfLevelBadge;

--- a/packages/directory-portal/src/components/ProductFootprintForm.tsx
+++ b/packages/directory-portal/src/components/ProductFootprintForm.tsx
@@ -1,8 +1,10 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { Button, Heading, Text, Box } from "@radix-ui/themes";
 import * as Form from "@radix-ui/react-form";
 import { FormField, TextField, SelectField } from "./ui";
 import { TagInput } from "./ui/TagInput";
+import { EmissionFactorSourcesInput } from "./ui/EmissionFactorSourcesInput";
+import { PcfLevelPanel } from "./PcfLevelBadge";
 import {
   ProductFootprint,
   CarbonFootprint,
@@ -10,6 +12,7 @@ import {
   CarbonFootprintGeographyRegionOrSubregion,
   CarbonFootprintCcuCalculationApproach,
   ProductFootprintStatus,
+  EmissionFactorSource,
 } from "pact-data-model/v3_0";
 
 /** Build SelectField option list from a string enum's values. Labels capitalize the first letter. */
@@ -31,7 +34,8 @@ const CCU_APPROACH_OPTIONS = [NONE_OPTION, ...enumToOptions(CarbonFootprintCcuCa
 type AllStrings<T> = { [K in keyof T]-?: string };
 
 // All CarbonFootprint fields collapsed to string (enum / bool / string[] → string).
-// Complex sub-objects not shown in the basic form are omitted.
+// Complex sub-objects not shown in the basic form are omitted, except
+// secondaryEmissionFactorSources which is edited as a structured array.
 export type CarbonFootprintFormData = AllStrings<
   Omit<CarbonFootprint,
     | 'productOrSectorSpecificRules'
@@ -39,7 +43,9 @@ export type CarbonFootprintFormData = AllStrings<
     | 'dqi'
     | 'verification'
   >
->;
+> & {
+  secondaryEmissionFactorSources: EmissionFactorSource[];
+};
 
 // ProductFootprint minus server-generated fields, with array fields kept and pcf typed for the form.
 export type ProductFootprintFormData = AllStrings<
@@ -112,6 +118,7 @@ function footprintToFormData(data: Partial<ProductFootprint>): ProductFootprintF
       ccsTechnologicalCO2CaptureIncluded: String(pcf.ccsTechnologicalCO2CaptureIncluded ?? false),
       ipccCharacterizationFactors: pcf.ipccCharacterizationFactors?.join(', ') ?? 'AR6',
       crossSectoralStandards: pcf.crossSectoralStandards?.join(', ') ?? 'PACT-3.0',
+      secondaryEmissionFactorSources: pcf.secondaryEmissionFactorSources ?? [],
     },
   } as ProductFootprintFormData;
 }
@@ -141,6 +148,12 @@ function formDataToFootprint(form: ProductFootprintFormData): ProductFootprint {
       ccsTechnologicalCO2CaptureIncluded: pcf.ccsTechnologicalCO2CaptureIncluded === 'true',
       ipccCharacterizationFactors: pcf.ipccCharacterizationFactors.split(',').map(s => s.trim()).filter(Boolean),
       crossSectoralStandards: pcf.crossSectoralStandards.split(',').map(s => s.trim()).filter(Boolean),
+      secondaryEmissionFactorSources: (() => {
+        const sources = (pcf.secondaryEmissionFactorSources ?? [])
+          .map((s) => ({ name: s.name.trim(), version: s.version.trim() }))
+          .filter((s) => s.name !== '' && s.version !== '');
+        return sources.length > 0 ? sources : undefined;
+      })(),
     },
   } as ProductFootprint;
 }
@@ -152,6 +165,17 @@ const ProductFootprintForm: React.FC<ProductFootprintFormProps> = ({
   readOnly = false,
 }) => {
   const [formData, setFormData] = useState<ProductFootprintFormData>(() => footprintToFormData(initialData ?? {}));
+
+  // Live PCF Usability Level source: current form values merged with the complex
+  // fields the form does not manage (e.g. secondaryEmissionFactorSources, dqi,
+  // verification), preserved from initialData so editing stays accurate.
+  const levelSource = useMemo(
+    () => ({
+      ...formData,
+      pcf: { ...(initialData?.pcf ?? {}), ...formData.pcf },
+    }),
+    [formData, initialData]
+  );
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (readOnly) return;
@@ -174,6 +198,9 @@ const ProductFootprintForm: React.FC<ProductFootprintFormProps> = ({
 
   return (
     <Form.Root onSubmit={handleSubmit} className="form-root">
+
+      {/* ── PCF Usability Level (updates live as the form is filled) ── */}
+      <PcfLevelPanel footprint={readOnly && initialData ? initialData : levelSource} />
 
       {/* ── Product Information ── */}
       <SectionHeading>Product Information</SectionHeading>
@@ -564,6 +591,23 @@ const ProductFootprintForm: React.FC<ProductFootprintFormProps> = ({
           <TextField value={formData.pcf.primaryDataShare} placeholder="e.g. 60.0" readOnly={readOnly} onChange={handlePcfChange} />
         </FormField>
       </FieldGrid>
+
+      <FormField
+        name="secondaryEmissionFactorSources"
+        label="Secondary Emission Factor Sources"
+        description="Secondary emission-factor databases used in the calculation (name and version). Required whenever secondary data was used."
+      >
+        <EmissionFactorSourcesInput
+          value={formData.pcf.secondaryEmissionFactorSources}
+          disabled={readOnly}
+          onChange={(secondaryEmissionFactorSources) =>
+            setFormData((prev) => ({
+              ...prev,
+              pcf: { ...prev.pcf, secondaryEmissionFactorSources },
+            }))
+          }
+        />
+      </FormField>
 
       <FormField name="exemptedEmissionsDescription" label="Exempted Emissions Description" description="Rationale behind exclusion of specific PCF emissions.">
         <TextField value={formData.pcf.exemptedEmissionsDescription} placeholder="Rationale for exclusions" readOnly={readOnly} onChange={handlePcfChange} />

--- a/packages/directory-portal/src/components/ui/EmissionFactorSourcesInput.tsx
+++ b/packages/directory-portal/src/components/ui/EmissionFactorSourcesInput.tsx
@@ -1,0 +1,92 @@
+import { Box, Button, Flex, IconButton, Text, TextField } from "@radix-ui/themes";
+import { PlusIcon, TrashIcon } from "@radix-ui/react-icons";
+import { EmissionFactorSource } from "pact-data-model/v3_0";
+
+interface EmissionFactorSourcesInputProps {
+  value: EmissionFactorSource[];
+  onChange: (value: EmissionFactorSource[]) => void;
+  disabled?: boolean;
+}
+
+/**
+ * Repeatable editor for `CarbonFootprint.secondaryEmissionFactorSources`, an
+ * array of `{ name, version }` pairs referencing secondary emission-factor
+ * databases (e.g. ecoinvent 3.9.1). In read-only mode the sources are rendered
+ * as plain text.
+ */
+export function EmissionFactorSourcesInput({
+  value,
+  onChange,
+  disabled = false,
+}: EmissionFactorSourcesInputProps) {
+  const rows = value ?? [];
+
+  const updateRow = (index: number, patch: Partial<EmissionFactorSource>) => {
+    onChange(rows.map((row, i) => (i === index ? { ...row, ...patch } : row)));
+  };
+
+  const addRow = () => onChange([...rows, { name: "", version: "" }]);
+
+  const removeRow = (index: number) => {
+    onChange(rows.filter((_, i) => i !== index));
+  };
+
+  if (disabled) {
+    if (rows.length === 0) {
+      return (
+        <Text size="2" color="gray">
+          —
+        </Text>
+      );
+    }
+    return (
+      <Flex direction="column" gap="1">
+        {rows.map((row, i) => (
+          <Text key={i} size="2">
+            {row.name || "—"}
+            {row.version ? ` · v${row.version}` : ""}
+          </Text>
+        ))}
+      </Flex>
+    );
+  }
+
+  return (
+    <Box>
+      {rows.length > 0 && (
+        <Flex direction="column" gap="2" mb="2">
+          {rows.map((row, i) => (
+            <Flex key={i} gap="2" align="center">
+              <Box style={{ flex: 2 }}>
+                <TextField.Root
+                  placeholder="Database name (e.g. ecoinvent)"
+                  value={row.name}
+                  onChange={(e) => updateRow(i, { name: e.target.value })}
+                />
+              </Box>
+              <Box style={{ flex: 1 }}>
+                <TextField.Root
+                  placeholder="Version (e.g. 3.9.1)"
+                  value={row.version}
+                  onChange={(e) => updateRow(i, { version: e.target.value })}
+                />
+              </Box>
+              <IconButton
+                type="button"
+                variant="soft"
+                color="red"
+                aria-label="Remove source"
+                onClick={() => removeRow(i)}
+              >
+                <TrashIcon />
+              </IconButton>
+            </Flex>
+          ))}
+        </Flex>
+      )}
+      <Button type="button" variant="soft" size="1" onClick={addRow}>
+        <PlusIcon /> Add source
+      </Button>
+    </Box>
+  );
+}

--- a/packages/directory-portal/src/pages/NodeDashboardPage.tsx
+++ b/packages/directory-portal/src/pages/NodeDashboardPage.tsx
@@ -41,6 +41,7 @@ import FulfillPcfRequestForm from "../components/FulfillPcfRequestForm";
 import NodeLink from "../components/NodeLink";
 import ConnectionCredentialsDialog from "../components/ConnectionCredentialsDialog";
 import DeleteNodeDialogs from "../components/DeleteNodeDialogs";
+import PcfLevelBadge from "../components/PcfLevelBadge";
 import {
   NodeData,
   ActivityLog,
@@ -388,6 +389,11 @@ const NodeDashboardPage: React.FC = () => {
         const value = pcf?.primaryDataShare as string | undefined;
         return <Text size="2">{value != null ? `${value}%` : "—"}</Text>;
       },
+    },
+    {
+      key: "data.level",
+      header: "Level",
+      render: (row) => <PcfLevelBadge footprint={row.data} size="1" />,
     },
     {
       key: "createdAt",

--- a/packages/directory-portal/src/utils/pcf-level.ts
+++ b/packages/directory-portal/src/utils/pcf-level.ts
@@ -1,0 +1,259 @@
+import { ProductFootprint } from "pact-data-model/v3_0";
+
+/**
+ * PCF Usability Model — PCF Levels (GitHub issue #328).
+ *
+ * Source of truth: WBCSD/PACT white paper
+ * "Using PCF Data in Practice: A Usability Model" (March 2026), Figure 2.
+ *
+ * The white paper defines three progressive PCF Levels that describe how
+ * complete and transparent a disclosed PCF dataset is (it is NOT a data-quality
+ * or accuracy score):
+ *
+ *  - Level 1 — Indicative PCF: a minimal dataset with core identification, unit
+ *    definition and cradle-to-gate emissions values.
+ *  - Level 2 — Consistent PCF: a Level 1 dataset plus metadata enabling some
+ *    evaluation of data reliability, representativeness and methodological
+ *    consistency.
+ *  - Level 3 — Methodologically Complete PCF: a Level 2 dataset that is
+ *    methodologically complete (100% of PACT SHALL attributes, transparency on
+ *    sources, choices and exclusions).
+ *
+ * (Level + — Conditional PCF is use-case specific and out of scope for automatic
+ * derivation.)
+ *
+ * A PCF is awarded the highest level for which that level and every lower level
+ * are fully populated. A gap in a lower level caps the achieved level.
+ *
+ * Note: the issue #328 refers to "grade 1/2/3"; the authoritative term from the
+ * white paper is "Level", which is used throughout this module.
+ */
+
+/** 0 = below Level 1 (incomplete), 1..3 = achieved PCF Level. */
+export type PcfLevel = 0 | 1 | 2 | 3;
+
+export type PcfLevelKey = "indicative" | "consistent" | "complete";
+
+type FootprintSource =
+  | Partial<ProductFootprint>
+  | Record<string, unknown>
+  | null
+  | undefined;
+
+export interface LevelField {
+  /** Dot-path to the value on the ProductFootprint (e.g. "pcf.fossilGhgEmissions"). */
+  path?: string;
+  /** The field is populated when *any* of these dot-paths is present (e.g. geography granularity). */
+  anyOf?: string[];
+  /** Human-readable label shown in the level breakdown. */
+  label: string;
+  /**
+   * "If applicable" attribute: shown for context but never required to reach the
+   * level, because applicability cannot be reliably inferred (per the white paper's
+   * conditional attributes, e.g. biogenic carbon content, product/sector rules).
+   */
+  optional?: boolean;
+  /** When provided, the field is only required if this predicate returns true. */
+  requiredWhen?: (footprint: FootprintSource) => boolean;
+}
+
+export interface PcfLevelTier {
+  level: 1 | 2 | 3;
+  key: PcfLevelKey;
+  /** Short name from the white paper (e.g. "Indicative"). */
+  title: string;
+  description: string;
+  fields: LevelField[];
+}
+
+/** Read a nested value from an object using a dot-path, without throwing. */
+function getByPath(source: unknown, path: string): unknown {
+  return path.split(".").reduce<unknown>((acc, key) => {
+    if (acc && typeof acc === "object") {
+      return (acc as Record<string, unknown>)[key];
+    }
+    return undefined;
+  }, source);
+}
+
+/** A value is "populated" unless it is nullish, an empty/whitespace string, or an empty array. Booleans (incl. false) count as populated. */
+function isValuePopulated(value: unknown): boolean {
+  if (value === undefined || value === null) return false;
+  if (typeof value === "string") return value.trim() !== "";
+  if (Array.isArray(value)) return value.length > 0;
+  return true;
+}
+
+/** True when the percentage of exempted emissions exceeds the PACT 3% threshold. */
+function exemptedEmissionsAbove3Percent(footprint: FootprintSource): boolean {
+  const raw = getByPath(footprint ?? {}, "pcf.exemptedEmissionsPercent");
+  const value = typeof raw === "number" ? raw : parseFloat(String(raw ?? ""));
+  return Number.isFinite(value) && value > 3;
+}
+
+// ── Level 1 — Indicative PCF ──
+const INDICATIVE_TIER: PcfLevelTier = {
+  level: 1,
+  key: "indicative",
+  title: "Indicative",
+  description:
+    "Core identification, unit definition and cradle-to-gate emissions value.",
+  fields: [
+    { path: "productNameCompany", label: "Product name" },
+    { path: "productDescription", label: "Product description" },
+    { path: "productIds", label: "Product IDs" },
+    { path: "productClassifications", label: "Product classification codes", optional: true },
+    { path: "status", label: "Status" },
+    { path: "pcf.pcfExcludingBiogenicUptake", label: "PCF excluding biogenic CO₂ uptake" },
+    { path: "pcf.declaredUnitOfMeasurement", label: "Declared unit" },
+    { path: "pcf.declaredUnitAmount", label: "Declared unit amount" },
+    { path: "pcf.productMassPerDeclaredUnit", label: "Product mass per declared unit" },
+    { path: "pcf.referencePeriodStart", label: "Reference period start" },
+    { path: "pcf.referencePeriodEnd", label: "Reference period end" },
+    {
+      anyOf: [
+        "pcf.geographyCountrySubdivision",
+        "pcf.geographyCountry",
+        "pcf.geographyRegionOrSubregion",
+      ],
+      label: "Geographic scope",
+    },
+  ],
+};
+
+// ── Level 2 — Consistent PCF ──
+const CONSISTENT_TIER: PcfLevelTier = {
+  level: 2,
+  key: "consistent",
+  title: "Consistent",
+  description:
+    "Adds metadata enabling evaluation of reliability, representativeness and methodological consistency.",
+  fields: [
+    { path: "pcf.pcfIncludingBiogenicUptake", label: "PCF including biogenic CO₂ uptake" },
+    { path: "pcf.biogenicCarbonContent", label: "Biogenic carbon content (if applicable)", optional: true },
+    { path: "pcf.primaryDataShare", label: "Primary data share (PDS)" },
+    { path: "pcf.secondaryEmissionFactorSources", label: "Secondary emission factor sources" },
+    { path: "pcf.packagingEmissionsIncluded", label: "Packaging emissions included" },
+    { path: "pcf.ipccCharacterizationFactors", label: "IPCC characterization factors" },
+    { path: "pcf.productOrSectorSpecificRules", label: "Product/sector-specific rules (if applicable)", optional: true },
+  ],
+};
+
+// ── Level 3 — Methodologically Complete PCF ──
+const COMPLETE_TIER: PcfLevelTier = {
+  level: 3,
+  key: "complete",
+  title: "Methodologically complete",
+  description:
+    "100% of PACT SHALL attributes, with transparency on boundary processes, allocation and exclusions.",
+  fields: [
+    { path: "pcf.boundaryProcessesDescription", label: "Boundary processes description" },
+    // Remaining PACT SHALL attributes not already covered by Levels 1–2.
+    { path: "companyName", label: "Company name" },
+    { path: "companyIds", label: "Company IDs" },
+    { path: "pcf.fossilGhgEmissions", label: "Fossil GHG emissions" },
+    { path: "pcf.fossilCarbonContent", label: "Fossil carbon content" },
+    { path: "pcf.crossSectoralStandards", label: "Cross-sectoral standards" },
+    { path: "pcf.exemptedEmissionsPercent", label: "Exempted emissions percent" },
+    { path: "pcf.allocationRulesDescription", label: "Allocation rules description" },
+    {
+      path: "pcf.exemptedEmissionsDescription",
+      label: "Exempted emissions description (exemptions > 3%)",
+      requiredWhen: exemptedEmissionsAbove3Percent,
+    },
+  ],
+};
+
+export const PCF_LEVEL_TIERS: readonly PcfLevelTier[] = [
+  INDICATIVE_TIER,
+  CONSISTENT_TIER,
+  COMPLETE_TIER,
+];
+
+/** Fields of a tier that are actually required for the given footprint (excludes optional & unmet conditionals). */
+function requiredFieldsFor(
+  tier: PcfLevelTier,
+  footprint: FootprintSource
+): LevelField[] {
+  return tier.fields.filter((field) => {
+    if (field.optional) return false;
+    if (field.requiredWhen && !field.requiredWhen(footprint)) return false;
+    return true;
+  });
+}
+
+/** Whether a single field is populated on the given footprint. */
+function isFieldPopulated(footprint: FootprintSource, field: LevelField): boolean {
+  const paths = field.anyOf ?? (field.path ? [field.path] : []);
+  return paths.some((path) => isValuePopulated(getByPath(footprint ?? {}, path)));
+}
+
+export interface TierStatus {
+  tier: PcfLevelTier;
+  /** Whether every required field in this tier is populated. */
+  complete: boolean;
+  populatedCount: number;
+  totalCount: number;
+  /** Required fields in this tier that are not yet populated. */
+  missingFields: LevelField[];
+}
+
+export interface PcfLevelResult {
+  level: PcfLevel;
+  /** Display label such as "Level 2" or "Incomplete". */
+  label: string;
+  /** Short human-readable name of the achieved tier (e.g. "Consistent"). */
+  tierName: string;
+  /** Radix Themes badge colour for the achieved level. */
+  color: "gray" | "bronze" | "blue" | "green";
+  tiers: TierStatus[];
+}
+
+const LEVEL_META: Record<
+  PcfLevel,
+  { label: string; tierName: string; color: PcfLevelResult["color"] }
+> = {
+  0: { label: "Incomplete", tierName: "Below Level 1", color: "gray" },
+  1: { label: "Level 1", tierName: "Indicative", color: "bronze" },
+  2: { label: "Level 2", tierName: "Consistent", color: "blue" },
+  3: { label: "Level 3", tierName: "Methodologically complete", color: "green" },
+};
+
+/**
+ * Compute the PCF Usability Model level for a footprint.
+ *
+ * The level is the highest tier for which that tier and every lower tier are
+ * fully populated. "If applicable" attributes and unmet conditional attributes
+ * do not block the level.
+ */
+export function computePcfLevel(footprint: FootprintSource): PcfLevelResult {
+  const source = footprint ?? {};
+
+  const tiers: TierStatus[] = PCF_LEVEL_TIERS.map((tier) => {
+    const required = requiredFieldsFor(tier, source);
+    const missingFields = required.filter((field) => !isFieldPopulated(source, field));
+    return {
+      tier,
+      complete: missingFields.length === 0,
+      populatedCount: required.length - missingFields.length,
+      totalCount: required.length,
+      missingFields,
+    };
+  });
+
+  // Level is capped at the first incomplete tier.
+  let level: PcfLevel = 0;
+  for (const status of tiers) {
+    if (!status.complete) break;
+    level = status.tier.level;
+  }
+
+  const meta = LEVEL_META[level];
+  return {
+    level,
+    label: meta.label,
+    tierName: meta.tierName,
+    color: meta.color,
+    tiers,
+  };
+}


### PR DESCRIPTION
Introduces the tier calculation for PCF form, based on the level of information that is being supplied. Also adds a few fields that were needed for Level 2 and 3.

<img width="777" height="309" alt="Screenshot 2026-07-23 at 12 26 34" src="https://github.com/user-attachments/assets/b41d1786-5e97-406d-b241-1e413c65ecd1" />
